### PR TITLE
add block_reader interface

### DIFF
--- a/fastavro/__init__.py
+++ b/fastavro/__init__.py
@@ -63,6 +63,7 @@ def _acquaint_schema(schema):
 
 
 reader = iter_avro = fastavro.read.reader
+block_reader = fastavro.read.block_reader
 schemaless_reader = fastavro.read.schemaless_reader
 load = fastavro.read.read_data
 writer = fastavro.write.writer

--- a/fastavro/_read_py.py
+++ b/fastavro/_read_py.py
@@ -480,20 +480,6 @@ def skip_sync(fo, sync_marker):
         raise ValueError('expected sync marker not found')
 
 
-class MemoryReader:
-    def __init__(self, data):
-        self._position = 0
-        self.data = data
-
-    def read(self, size):
-        result = self.data[self._position: self._position + size]
-        self._position += size
-        return result
-
-    def tell(self):
-        return self._position
-
-
 def null_read_block(fo):
     """Read block in "null" codec."""
     return MemoryIO(read_bytes(fo))

--- a/fastavro/read.py
+++ b/fastavro/read.py
@@ -9,6 +9,7 @@ from ._read_common import (
 
 acquaint_schema = _read.acquaint_schema
 reader = iter_avro = _read.reader
+block_reader = _read.block_reader
 schemaless_reader = _read.schemaless_reader
 read_data = _read.read_data
 is_avro = _read.is_avro

--- a/tag.sh
+++ b/tag.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Fail on 1'st error
+# Fail on 1st error
 set -e
 set -x
 

--- a/tests/test_block_reader.py
+++ b/tests/test_block_reader.py
@@ -1,20 +1,22 @@
 
 import fastavro
 from fastavro.six import MemoryIO
+from tempfile import NamedTemporaryFile
 
 schema = {
     "type": "record",
     "name": "test_block_iteration",
-    "fields": [{
-        "name": "nullable_str",
-        "type": ["string", "null"]
-    }, {
-        "name": "str_field",
-        "type": "string"
-    }, {
-        "name": "int_field",
-        "type": "int"
-    }
+    "fields": [
+        {
+            "name": "nullable_str",
+            "type": ["string", "null"]
+        }, {
+            "name": "str_field",
+            "type": "string"
+        }, {
+            "name": "int_field",
+            "type": "int"
+        }
     ]
 }
 
@@ -30,17 +32,19 @@ def make_records(num_records=2000):
     ]
 
 
-def make_blocks(num_records=2000, codec='null'):
+def make_blocks(num_records=2000, codec='null', write_to_disk=False):
     records = make_records(num_records)
 
-    new_file = MemoryIO()
+    new_file = NamedTemporaryFile() if write_to_disk else MemoryIO()
     fastavro.writer(new_file, schema, records, codec=codec)
     bytes = new_file.tell()
-    new_file.seek(0)
 
+    new_file.seek(0)
     block_reader = fastavro.block_reader(new_file, schema)
 
     blocks = list(block_reader)
+
+    new_file.close()
 
     return blocks, records, bytes
 
@@ -58,9 +62,9 @@ def check_block(block, num_bytes, num_records, records, codec, offset, size):
     assert block_records == records
 
 
-def test_block_iteration():
+def check_round_trip(write_to_disk):
 
-    blocks, records, bytes = make_blocks()
+    blocks, records, bytes = make_blocks(write_to_disk=write_to_disk)
 
     assert bytes == 46007
 
@@ -69,12 +73,32 @@ def test_block_iteration():
     check_block(blocks[2], 13677, 533, records[811+656:       ], 'null', 32309, 13698)  # noqa
 
 
-def test_block_iteration_deflated():
+def check_round_trip_deflated(write_to_disk):
 
-    blocks, records, bytes = make_blocks(codec='deflate')
+    blocks, records, bytes = \
+        make_blocks(
+            codec='deflate',
+            write_to_disk=write_to_disk
+        )
 
     assert bytes == 16543
 
     check_block(blocks[0], 16004, 811, records[       :811    ], 'deflate',   250, 6242)  # noqa
     check_block(blocks[1], 16016, 656, records[    811:811+656], 'deflate',  6492, 5624)  # noqa
     check_block(blocks[2], 13677, 533, records[811+656:       ], 'deflate', 12116, 4427)  # noqa
+
+
+def test_block_iteration_disk():
+    check_round_trip(write_to_disk=True)
+
+
+def test_block_iteration_memory():
+    check_round_trip(write_to_disk=False)
+
+
+def test_block_iteration_deflated_disk():
+    check_round_trip(write_to_disk=True)
+
+
+def test_block_iteration_deflated_memory():
+    check_round_trip(write_to_disk=False)

--- a/tests/test_block_reader.py
+++ b/tests/test_block_reader.py
@@ -48,7 +48,7 @@ def make_blocks(num_records=2000, codec='null'):
 def check_block(block, num_bytes, num_records, records, codec, offset, size):
     block_records = list(block)
 
-    assert len(block.bytes) == num_bytes
+    assert len(block.bytes_) == num_bytes
     assert len(block_records) == num_records
     assert block.codec == codec
     assert block.reader_schema == schema

--- a/tests/test_block_reader.py
+++ b/tests/test_block_reader.py
@@ -1,0 +1,80 @@
+
+import fastavro
+from fastavro.six import MemoryIO
+
+schema = {
+    "type": "record",
+    "name": "test_block_iteration",
+    "fields": [{
+        "name": "nullable_str",
+        "type": ["string", "null"]
+    }, {
+        "name": "str_field",
+        "type": "string"
+    }, {
+        "name": "int_field",
+        "type": "int"
+    }
+    ]
+}
+
+
+def make_records(num_records=2000):
+    return [
+        {
+            "nullable_str": None if i % 3 == 0 else "%d-%d" % (i, i),
+            "str_field": "%d %d %d" % (i, i, i),
+            "int_field": i * 10
+        }
+        for i in range(num_records)
+    ]
+
+
+def make_blocks(num_records=2000, codec='null'):
+    records = make_records(num_records)
+
+    new_file = MemoryIO()
+    fastavro.writer(new_file, schema, records, codec=codec)
+    bytes = new_file.tell()
+    new_file.seek(0)
+
+    block_reader = fastavro.block_reader(new_file, schema)
+
+    blocks = list(block_reader)
+
+    return blocks, records, bytes
+
+
+def check_block(block, num_bytes, num_records, records, codec, offset, size):
+    block_records = list(block)
+
+    assert len(block.bytes) == num_bytes
+    assert len(block_records) == num_records
+    assert block.codec == codec
+    assert block.reader_schema == schema
+    assert block.writer_schema == schema
+    assert block.offset == offset
+    assert block.size == size
+    assert block_records == records
+
+
+def test_block_iteration():
+
+    blocks, records, bytes = make_blocks()
+
+    assert bytes == 46007
+
+    check_block(blocks[0], 16004, 811, records[       :811    ], 'null',   247, 16025)  # noqa
+    check_block(blocks[1], 16016, 656, records[    811:811+656], 'null', 16272, 16037)  # noqa
+    check_block(blocks[2], 13677, 533, records[811+656:       ], 'null', 32309, 13698)  # noqa
+
+
+def test_block_iteration_deflated():
+
+    blocks, records, bytes = make_blocks(codec='deflate')
+
+    assert bytes == 16543
+
+    check_block(blocks[0], 16004, 811, records[       :811    ], 'deflate',   250, 6242)  # noqa
+    check_block(blocks[1], 16016, 656, records[    811:811+656], 'deflate',  6492, 5624)  # noqa
+    check_block(blocks[2], 13677, 533, records[811+656:       ], 'deflate', 12116, 4427)  # noqa

--- a/tests/test_block_reader.py
+++ b/tests/test_block_reader.py
@@ -52,7 +52,6 @@ def make_blocks(num_records=2000, codec='null', write_to_disk=False):
 def check_block(block, num_bytes, num_records, records, codec, offset, size):
     block_records = list(block)
 
-    assert len(block.bytes_) == num_bytes
     assert len(block_records) == num_records
     assert block.codec == codec
     assert block.reader_schema == schema

--- a/tests/test_fastavro.py
+++ b/tests/test_fastavro.py
@@ -49,6 +49,9 @@ class NoSeekMemoryIO(object):
     def read(self, n):
         return self.underlying.read(n)
 
+    def tell(self):
+        return self.underlying.tell()
+
     def seek(self, *args):
         raise AssertionError("fastavro reader should not depend on seek")
 

--- a/tests/test_fastavro.py
+++ b/tests/test_fastavro.py
@@ -23,10 +23,10 @@ try:
 except ImportError:
     has_snappy = False
 
-NO_DATA = set([
+NO_DATA = {
     'class org.apache.avro.tool.TestDataFileTools.zerojsonvalues.avro',
     'testDataFileMeta.avro',
-])
+}
 
 
 def roundtrip(schema, records):


### PR DESCRIPTION
[Apache Beam is interested in using fastavro instead of apache/avro](https://issues.apache.org/jira/browse/BEAM-2810), but needs an interface like I've added here, for seeking to and reading individual record-blocks in a file.

[I've published this as `fastavro-blocks:0.19.5.4` to test.pypi.org](https://test.pypi.org/project/fastavro-blocks/0.19.5.4/) (cf. [`blocks-test-pypi` branch](https://github.com/ryan-williams/fastavro/tree/blocks-test-pypi), which has [a commit on top of this PR changing the name and version](https://github.com/ryan-williams/fastavro/commit/e602bddefea6e3a369ddbd5c3695cf3d700da586)), and [used that in a Beam branch here](https://github.com/ryan-williams/beam/tree/fastavro).

Presumably it can't go into Beam until it's in real pypi, so that will have to wait until the next release here, though those seem to happen quite frequently 🎉😀

In this change I introduced a block-iteration interface, and had the standard record-iterator wrap it. I also did a few random tweaks to make _read{.pyx,_py.py} diff more cleanly against one another.

I'm new to Cython and haven't figured out when `_read_py.py` would be used instead of `_read.pyx`; a previous version of this PR failed Travis' pypy builds due to a bug I introduced in `_read_py.py`, so I guess it's covered?

