### PR TITLE
add option to skip parsing

### DIFF
--- a/benchmark/benchmark.py
+++ b/benchmark/benchmark.py
@@ -2,7 +2,7 @@ from io import BytesIO
 import datetime
 import time
 
-from fastavro import writer, reader, schemaless_writer, schemaless_reader
+from fastavro import writer, reader, schemaless_writer, schemaless_reader, acquaint_schema
 from fastavro._timezone import utc
 
 from fastavro.validation import validate, validate_many
@@ -13,7 +13,7 @@ def write(schema, records, runs=1):
     for _ in range(runs):
         iostream = BytesIO()
         start = time.time()
-        writer(iostream, schema, records)
+        writer(iostream, schema, records, parse_schema=False)
         end = time.time()
         times.append(end - start)
     print('... {0} runs averaged {1} seconds'.format(runs, (sum(times) / runs)))
@@ -26,7 +26,7 @@ def write_schemaless(schema, records, runs=1):
         for record in records:
             iostream = BytesIO()
             start = time.time()
-            schemaless_writer(iostream, schema, record)
+            schemaless_writer(iostream, schema, record, parse_schema=False)
             end = time.time()
             times.append(end - start)
     print('... {0} runs averaged {1} seconds'.format(runs, (sum(times) / runs)))
@@ -50,7 +50,7 @@ def read(iostream, runs=1):
     for _ in range(runs):
         iostream.seek(0)
         start = time.time()
-        records = list(reader(iostream))
+        records = list(reader(iostream, parse_schema=False))
         end = time.time()
         times.append(end - start)
     print('... {0} runs averaged {1} seconds'.format(runs, (sum(times) / runs)))
@@ -63,7 +63,7 @@ def read_schemaless(iostream, schema, num_records, runs=1):
         for _ in range(num_records):
             iostream.seek(0)
             start = time.time()
-            record = schemaless_reader(iostream, schema)
+            record = schemaless_reader(iostream, schema, parse_schema=False)
             end = time.time()
             times.append(end - start)
     print('... {0} runs averaged {1} seconds'.format(runs, (sum(times) / runs)))
@@ -178,6 +178,7 @@ for desc, schema, single_record, num_records, num_runs in configurations:
     print(desc)
     original_records = [single_record for _ in range(num_records)]
 
+    acquaint_schema(schema)
     print('Writing {0} records to one file...'.format(num_records))
     bytesio = write(schema, original_records, runs=num_runs)
 

--- a/fastavro/_read.pyx
+++ b/fastavro/_read.pyx
@@ -659,7 +659,7 @@ class Block:
 
 
 class file_reader:
-    def __init__(self, fo, reader_schema=None):
+    def __init__(self, fo, reader_schema=None, parse_schema=True):
         self.fo = fo
         try:
             self._header = _read_data(self.fo, HEADER_SCHEMA)
@@ -681,7 +681,8 @@ class file_reader:
             # No need for the reader schema if they are the same
             reader_schema = None
 
-        acquaint_schema(self.writer_schema)
+        if parse_schema:
+            acquaint_schema(self.writer_schema)
         if reader_schema:
             populate_schema_defs(reader_schema)
 
@@ -720,8 +721,9 @@ class block_reader(file_reader):
                                         reader_schema)
 
 
-cpdef schemaless_reader(fo, writer_schema, reader_schema=None):
-    acquaint_schema(writer_schema)
+cpdef schemaless_reader(fo, writer_schema, reader_schema=None, parse_schema=True):
+    if parse_schema:
+        acquaint_schema(writer_schema)
 
     if writer_schema == reader_schema:
         # No need for the reader schema if they are the same

--- a/fastavro/_read_py.py
+++ b/fastavro/_read_py.py
@@ -581,7 +581,7 @@ class Block:
 
 
 class file_reader:
-    def __init__(self, fo, reader_schema=None):
+    def __init__(self, fo, reader_schema=None, parse_schema=True):
         self.fo = fo
         try:
             self._header = read_data(self.fo, HEADER_SCHEMA)
@@ -603,7 +603,8 @@ class file_reader:
             # No need for the reader schema if they are the same
             reader_schema = None
 
-        acquaint_schema(self.writer_schema)
+        if parse_schema:
+            acquaint_schema(self.writer_schema)
         if reader_schema:
             populate_schema_defs(reader_schema)
 
@@ -684,7 +685,10 @@ class block_reader(file_reader):
                                         reader_schema)
 
 
-def schemaless_reader(fo, writer_schema, reader_schema=None):
+def schemaless_reader(fo,
+                      writer_schema,
+                      reader_schema=None,
+                      parse_schema=True):
     """Reads a single record writen using the schemaless_writer
 
     Parameters
@@ -706,7 +710,8 @@ def schemaless_reader(fo, writer_schema, reader_schema=None):
 
     Note: The ``schemaless_reader`` can only read a single record.
     """
-    acquaint_schema(writer_schema)
+    if parse_schema:
+        acquaint_schema(writer_schema)
 
     if writer_schema == reader_schema:
         # No need for the reader schema if they are the same

--- a/fastavro/_write.pyx
+++ b/fastavro/_write.pyx
@@ -649,7 +649,8 @@ cdef class Writer(object):
                  codec='null',
                  sync_interval=1000 * SYNC_SIZE,
                  metadata=None,
-                 validator=None):
+                 validator=None,
+                 parse_schema=True):
         cdef bytearray tmp = bytearray()
         self.fo = fo
         self.schema = schema
@@ -669,7 +670,8 @@ cdef class Writer(object):
 
         write_header(tmp, self.metadata, self.sync_marker)
         self.fo.write(tmp)
-        acquaint_schema(self.schema)
+        if parse_schema:
+            acquaint_schema(self.schema)
 
     def dump(self):
         cdef bytearray tmp = bytearray()
@@ -700,7 +702,8 @@ def writer(fo,
            codec='null',
            sync_interval=1000 * SYNC_SIZE,
            metadata=None,
-           validator=None):
+           validator=None,
+           parse_schema=True):
     output = Writer(
         fo,
         schema,
@@ -708,6 +711,7 @@ def writer(fo,
         sync_interval,
         metadata,
         validator,
+        parse_schema,
     )
 
     for record in records:
@@ -715,9 +719,10 @@ def writer(fo,
     output.flush()
 
 
-def schemaless_writer(fo, schema, record):
+def schemaless_writer(fo, schema, record, parse_schema=True):
     cdef bytearray tmp = bytearray()
-    acquaint_schema(schema)
+    if parse_schema:
+        acquaint_schema(schema)
     write_data(tmp, record, schema)
     fo.write(tmp)
 

--- a/fastavro/_write_py.py
+++ b/fastavro/_write_py.py
@@ -488,7 +488,8 @@ class Writer(object):
                  codec='null',
                  sync_interval=1000 * SYNC_SIZE,
                  metadata=None,
-                 validator=None):
+                 validator=None,
+                 parse_schema=True):
         self.fo = fo
         self.schema = schema
         self.validate_fn = validate if validator is True else validator
@@ -506,7 +507,8 @@ class Writer(object):
             raise ValueError('unrecognized codec: %r' % codec)
 
         write_header(self.fo, self.metadata, self.sync_marker)
-        acquaint_schema(self.schema)
+        if parse_schema:
+            acquaint_schema(self.schema)
 
     def dump(self):
         write_long(self.fo, self.block_count)
@@ -536,7 +538,8 @@ def writer(fo,
            codec='null',
            sync_interval=1000 * SYNC_SIZE,
            metadata=None,
-           validator=None):
+           validator=None,
+           parse_schema=True):
     """Write records to fo (stream) according to schema
 
     Parameters
@@ -592,6 +595,7 @@ def writer(fo,
         sync_interval,
         metadata,
         validator,
+        parse_schema
     )
 
     for record in records:
@@ -599,7 +603,7 @@ def writer(fo,
     output.flush()
 
 
-def schemaless_writer(fo, schema, record):
+def schemaless_writer(fo, schema, record, parse_schema=True):
     """Write a single record without the schema or header information
 
     Parameters
@@ -620,5 +624,6 @@ def schemaless_writer(fo, schema, record):
 
     Note: The ``schemaless_writer`` can only write a single record.
     """
-    acquaint_schema(schema)
+    if parse_schema:
+        acquaint_schema(schema)
     write_data(fo, record, schema)


### PR DESCRIPTION
Work in progress... Not planning to merge yet... Just want CI testing...

One possible option for a type of caching. Allows the user to call `acquaint_schema` one time and then always call operations with `parse_schema=False`.

NOTE: Probably want to change the name `acquaint_schema` to `parse_schema` or something like that... Could always leave in a `acquaint_schema = parse_schema` for a deprecation period.

NOTE: Would also need to update docs