### PR TITLE
fix field name when validating arrays

### DIFF
--- a/fastavro/schema.py
+++ b/fastavro/schema.py
@@ -5,7 +5,7 @@ except ImportError:
 
 from ._schema_common import UnknownType
 
-schema_name = _schema.schema_name
+_schema_name = _schema.schema_name
 load_schema = _schema.load_schema
 extract_record_type = _schema.extract_record_type
 populate_schema_defs = _schema.populate_schema_defs

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -234,6 +234,54 @@ def test_validator_numeric():
     # and plenty more to add I suppose
 
 
+def test_validate_array():
+    my_schema = {
+        "fields": [
+            {
+                "name": "array",
+                "type": {
+                    "type": "array",
+                    "items": "string",
+                },
+            },
+        ],
+        "namespace": "namespace",
+        "name": "test_validate_array",
+        "type": "record"
+    }
+
+    datum = {"array": [1]}
+    with pytest.raises(ValidationError) as exc:
+        validate(datum, my_schema)
+
+    for error in exc.value.errors:
+        assert error.field == 'namespace.test_validate_array.array'
+
+
+def test_validate_map():
+    my_schema = {
+        "fields": [
+            {
+                "name": "map",
+                "type": {
+                    "type": "map",
+                    "values": "string",
+                },
+            },
+        ],
+        "namespace": "namespace",
+        "name": "test_validate_map",
+        "type": "record"
+    }
+
+    datum = {"map": {"key": 1}}
+    with pytest.raises(ValidationError) as exc:
+        validate(datum, my_schema)
+
+    for error in exc.value.errors:
+        assert error.field == 'namespace.test_validate_map.map'
+
+
 def test_validator_numeric_numpy():
     np_ints = [
         np.int_,


### PR DESCRIPTION
When running the following snippet...

```python
my_schema = {
    "fields": [
        {
            "name": "array",
            "type": {
                "type": "array",
                "items": "string",
            },
        },
    ],
    "namespace": "namespace",
    "name": "test_validate_array",
    "type": "record"
}

datum = {"array": [1]}
validate(datum, my_schema)
```

An exception with this message is produced:

```python
fastavro._validate_common.ValidationError: [
  " is <1> of type <class 'int'> expected string"
]
```

This change will make sure the field name shows up correctly like so:

```python
fastavro._validate_common.ValidationError: [
  "namespace.test_validate_array.array is <1> of type <class 'int'> expected string"
]
```