### PR TITLE
remove load and dump APIs

### DIFF
--- a/fastavro/__init__.py
+++ b/fastavro/__init__.py
@@ -65,10 +65,8 @@ def _acquaint_schema(schema):
 reader = iter_avro = fastavro.read.reader
 block_reader = fastavro.read.block_reader
 schemaless_reader = fastavro.read.schemaless_reader
-load = fastavro.read.read_data
 writer = fastavro.write.writer
 schemaless_writer = fastavro.write.schemaless_writer
-dump = fastavro.write.dump
 acquaint_schema = _acquaint_schema
 fastavro.schema.acquaint_schema = _acquaint_schema
 is_avro = fastavro.read.is_avro

--- a/fastavro/_read.pyx
+++ b/fastavro/_read.pyx
@@ -720,10 +720,6 @@ class block_reader(file_reader):
                                         reader_schema)
 
 
-# Deprecated
-iter_avro = reader
-
-
 cpdef schemaless_reader(fo, writer_schema, reader_schema=None):
     acquaint_schema(writer_schema)
 

--- a/fastavro/_read_py.py
+++ b/fastavro/_read_py.py
@@ -684,10 +684,6 @@ class block_reader(file_reader):
                                         reader_schema)
 
 
-# Deprecated
-iter_avro = reader
-
-
 def schemaless_reader(fo, writer_schema, reader_schema=None):
     """Reads a single record writen using the schemaless_writer
 

--- a/fastavro/read.py
+++ b/fastavro/read.py
@@ -17,12 +17,11 @@ BLOCK_READERS = _read.BLOCK_READERS
 reader = iter_avro = _read.reader
 block_reader = _read.block_reader
 schemaless_reader = _read.schemaless_reader
-read_data = _read.read_data
 is_avro = _read.is_avro
 LOGICAL_READERS = _read.LOGICAL_READERS
 SchemaResolutionError = _read_common.SchemaResolutionError
 
 __all__ = [
-    'reader', 'schemaless_reader', 'read_data', 'is_avro', 'block_reader',
+    'reader', 'schemaless_reader', 'is_avro', 'block_reader',
     'SchemaResolutionError', 'LOGICAL_READERS',
 ]

--- a/fastavro/write.py
+++ b/fastavro/write.py
@@ -9,7 +9,6 @@ acquaint_schema = _write.acquaint_schema
 WRITERS = _write.WRITERS
 
 # Public API
-dump = _write.dump
 writer = _write.writer
 Writer = _write.Writer
 schemaless_writer = _write.schemaless_writer
@@ -17,6 +16,5 @@ write_data = _write.write_data
 LOGICAL_WRITERS = _write.LOGICAL_WRITERS
 
 __all__ = [
-    'dump', 'writer', 'Writer', 'schemaless_writer', 'write_data',
-    'LOGICAL_WRITERS',
+    'writer', 'Writer', 'schemaless_writer', 'write_data', 'LOGICAL_WRITERS',
 ]

--- a/tests/test_fastavro.py
+++ b/tests/test_fastavro.py
@@ -748,15 +748,10 @@ def test_schema_migration_schema_mismatch():
 
 def test_empty():
     io = MemoryIO()
-    schema = {
-        'type': 'record',
-        'name': 'test',
-        'fields': [
-            {'type': 'boolean', 'name': 'a'}
-        ],
-    }
-    with pytest.raises(EOFError):
-        fastavro.load(io, schema)
+    with pytest.raises(ValueError) as exc:
+        fastavro.reader(io)
+
+    assert 'cannot read header - is it an avro file?' in str(exc)
 
 
 def test_no_default():
@@ -768,13 +763,10 @@ def test_no_default():
             {'type': 'boolean', 'name': 'a'}
         ],
     }
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError) as exc:
         fastavro.writer(io, schema, [{}])
 
-
-@pytest.mark.skip(reason='FIXME: Add tests for write validator argument')
-def test_validator():
-    pass
+    assert 'no value and no default' in str(exc)
 
 
 def test_is_avro_str():
@@ -1040,34 +1032,6 @@ def test_union_records():
     }]
 
     assert data == roundtrip(schema, data)
-
-
-def test_dump_load(tmpdir):
-    """
-    Write an Avro record to a file using the dump() function and loads it back
-    using the load() function.
-    """
-    schema = {
-        "type": "record",
-        "name": "Test",
-        "namespace": "test",
-        "fields": [
-            {
-                "name": "field",
-                "type": {"type": "string"}
-            }
-        ]
-    }
-    record = {"field": "foobar"}
-
-    temp_path = tmpdir.join('test_dump.avro')
-    with temp_path.open('wb') as fo:
-        fastavro.dump(fo, record, schema)
-
-    with temp_path.open('rb') as fo:
-        new_record = fastavro.load(fo, schema)
-
-    assert record == new_record
 
 
 def test_ordered_dict_record():


### PR DESCRIPTION
These APIs are not documented and probably not useful in general. Using the normal `reader` and `writer` interface is the better way to go.