### PR TITLE
implement a parse_schema function

### DIFF
--- a/benchmark/benchmark.py
+++ b/benchmark/benchmark.py
@@ -2,7 +2,7 @@ from io import BytesIO
 import datetime
 import time
 
-from fastavro import writer, reader, schemaless_writer, schemaless_reader
+from fastavro import writer, reader, schemaless_writer, schemaless_reader, parse_schema
 from fastavro._timezone import utc
 
 from fastavro.validation import validate, validate_many
@@ -10,6 +10,7 @@ from fastavro.validation import validate, validate_many
 
 def write(schema, records, runs=1):
     times = []
+    schema = parse_schema(schema)
     for _ in range(runs):
         iostream = BytesIO()
         start = time.time()
@@ -22,6 +23,7 @@ def write(schema, records, runs=1):
 
 def write_schemaless(schema, records, runs=1):
     times = []
+    schema = parse_schema(schema)
     for _ in range(runs):
         for record in records:
             iostream = BytesIO()
@@ -36,6 +38,7 @@ def write_schemaless(schema, records, runs=1):
 def validater(schema, records, runs=1):
     times = []
     valid = []
+    schema = parse_schema(schema)
     for _ in range(runs):
         start = time.time()
         valid = validate_many(records, schema)
@@ -59,6 +62,7 @@ def read(iostream, runs=1):
 
 def read_schemaless(iostream, schema, num_records, runs=1):
     times = []
+    schema = parse_schema(schema)
     for _ in range(runs):
         for _ in range(num_records):
             iostream.seek(0)

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -22,9 +22,7 @@ Example
 -------
 
 ::
-
-    # Writing
-    from fastavro import writer
+    from fastavro import writer, reader, parse_schema
 
     schema = {
         'doc': 'A weather reading.',
@@ -37,6 +35,7 @@ Example
             {'name': 'temp', 'type': 'int'},
         ],
     }
+    parsed_schema = parse_schema(schema)
 
     # 'records' can be an iterable (including generator)
     records = [
@@ -46,17 +45,13 @@ Example
         {u'station': u'012650-99999', u'temp': 111, u'time': 1433275478},
     ]
 
+    # Writing
     with open('weather.avro', 'wb') as out:
-        writer(out, schema, records)
+        writer(out, parsed_schema, records)
 
     # Reading
-    import fastavro
-
     with open('weather.avro', 'rb') as fo:
-        reader = fastavro.reader(fo)
-        schema = reader.schema
-
-        for record in reader:
+        for record in reader(fo):
             print(record)
 
 
@@ -68,6 +63,7 @@ Documentation
 
    reader
    writer
+   schema
    validation
    command_line_script
 

--- a/docs/schema.rst
+++ b/docs/schema.rst
@@ -1,0 +1,4 @@
+fastavro.schema
+===============
+
+.. autofunction:: fastavro._schema_py.parse_schema

--- a/fastavro/__init__.py
+++ b/fastavro/__init__.py
@@ -49,28 +49,14 @@ import fastavro.write
 import fastavro.schema
 import fastavro.validation
 
-
-def _acquaint_schema(schema):
-    """Add a new schema to the schema repo.
-
-    Parameters
-    ----------
-    schema: dict
-        Schema to add to repo
-    """
-    fastavro.read.acquaint_schema(schema)
-    fastavro.write.acquaint_schema(schema)
-
-
 reader = iter_avro = fastavro.read.reader
 block_reader = fastavro.read.block_reader
 schemaless_reader = fastavro.read.schemaless_reader
 writer = fastavro.write.writer
 schemaless_writer = fastavro.write.schemaless_writer
-acquaint_schema = _acquaint_schema
-fastavro.schema.acquaint_schema = _acquaint_schema
 is_avro = fastavro.read.is_avro
 validate = fastavro.validation.validate
+parse_schema = fastavro.schema.parse_schema
 
 __all__ = [
     n for n in locals().keys() if not n.startswith('_')

--- a/fastavro/_read.pyx
+++ b/fastavro/_read.pyx
@@ -17,10 +17,7 @@ import json
 from ._six import (
     btou, iteritems, is_str, str2ints, fstint
 )
-from ._schema import (
-    extract_record_type, extract_named_schemas_into_repo, populate_schema_defs,
-    extract_logical_type
-)
+from ._schema import extract_record_type, extract_logical_type, parse_schema
 from ._schema_common import SCHEMA_DEFS
 from ._read_common import (
     SchemaResolutionError, MAGIC, SYNC_SIZE, HEADER_SCHEMA
@@ -498,12 +495,6 @@ LOGICAL_READERS = {
     'long-time-micros': read_time_micros,
 }
 
-READERS = {}
-
-
-cpdef read_data(fo, writer_schema, reader_schema=None):
-    return _read_data(fo, writer_schema, reader_schema)
-
 
 cpdef _read_data(fo, writer_schema, reader_schema=None):
     """Read data from file object according to schema."""
@@ -542,8 +533,11 @@ cpdef _read_data(fo, writer_schema, reader_schema=None):
         elif record_type == 'record' or record_type == 'error':
             data = read_record(fo, writer_schema, reader_schema)
         else:
-            fn = READERS[record_type]
-            data = fn(fo, writer_schema, reader_schema)
+            return _read_data(
+                fo,
+                SCHEMA_DEFS[record_type],
+                SCHEMA_DEFS.get(reader_schema)
+            )
     except ReadError:
         raise EOFError('cannot read %s from %s' % (record_type, fo))
 
@@ -592,16 +586,6 @@ try:
     BLOCK_READERS['snappy'] = snappy_read_block
 except ImportError:
     pass
-
-
-def acquaint_schema(schema):
-    """Extract schema into READERS"""
-    extract_named_schemas_into_repo(
-        schema,
-        READERS,
-        lambda schema: lambda fo, _, r_schema: read_data(
-            fo, schema, SCHEMA_DEFS.get(r_schema)),
-    )
 
 
 def _iter_avro_records(fo, header, codec, writer_schema, reader_schema):
@@ -671,19 +655,19 @@ class file_reader:
             k: btou(v) for k, v in iteritems(self._header['meta'])
         }
 
-        self.schema = self.writer_schema = \
-            json.loads(self.metadata['avro.schema'])
+        self.schema = json.loads(self.metadata['avro.schema'])
         self.codec = self.metadata.get('avro.codec', 'null')
 
         self.reader_schema = reader_schema
 
-        if self.writer_schema == reader_schema:
+        if self.schema == reader_schema:
             # No need for the reader schema if they are the same
             reader_schema = None
 
-        acquaint_schema(self.writer_schema)
+        self.writer_schema = parse_schema(self.schema, _write_hint=False)
+
         if reader_schema:
-            populate_schema_defs(reader_schema)
+            self.reader_schema = parse_schema(reader_schema, _write_hint=False)
 
         self._elems = None
 
@@ -721,16 +705,16 @@ class block_reader(file_reader):
 
 
 cpdef schemaless_reader(fo, writer_schema, reader_schema=None):
-    acquaint_schema(writer_schema)
-
     if writer_schema == reader_schema:
         # No need for the reader schema if they are the same
         reader_schema = None
 
-    if reader_schema:
-        populate_schema_defs(reader_schema)
+    writer_schema = parse_schema(writer_schema)
 
-    return read_data(fo, writer_schema, reader_schema)
+    if reader_schema:
+        reader_schema = parse_schema(reader_schema)
+
+    return _read_data(fo, writer_schema, reader_schema)
 
 
 cpdef is_avro(path_or_buffer):

--- a/fastavro/_schema.pyx
+++ b/fastavro/_schema.pyx
@@ -4,8 +4,10 @@ from os import path
 
 import json
 
+from ._six import iteritems
 from ._schema_common import (
-    PRIMITIVES, NAMED_TYPES, SCHEMA_DEFS, UnknownType, SchemaParseException
+    PRIMITIVES, UnknownType, SchemaParseException, RESERVED_PROPERTIES,
+    SCHEMA_DEFS,
 )
 
 
@@ -44,72 +46,111 @@ def schema_name(schema, parent_ns):
     if not namespace:
         return namespace, name
 
-    return namespace, '%s.%s' % (namespace, name)
+    return namespace, '{}.{}'.format(namespace, name)
 
 
-def extract_named_schemas_into_repo(schema, repo, transformer, parent_ns=None):
-    if isinstance(schema, list):
-        for index, enum_schema in enumerate(schema):
-            namespaced_name = extract_named_schemas_into_repo(
-                enum_schema,
-                repo,
-                transformer,
-                parent_ns,
-            )
-            if namespaced_name:
-                schema[index] = namespaced_name
-        return
-
-    if not isinstance(schema, dict):
-        # If a reference to another schema is an unqualified name, but not one
-        # of the primitive types, then we should add the current enclosing
-        # namespace to reference name.
-        if schema not in PRIMITIVES:
-            if '.' not in schema and parent_ns:
-                schema = parent_ns + '.' + schema
-
-            if schema not in repo:
-                raise UnknownType(schema)
-            return schema
-        return
-
-    schema_type = schema.get('type')
-    if schema_type == 'array':
-        namespaced_name = extract_named_schemas_into_repo(
-            schema['items'],
-            repo,
-            transformer,
-            parent_ns,
-        )
-        if namespaced_name:
-            schema['items'] = namespaced_name
-        return
-    elif schema_type == 'map':
-        namespaced_name = extract_named_schemas_into_repo(
-            schema['values'],
-            repo,
-            transformer,
-            parent_ns,
-        )
-        if namespaced_name:
-            schema['values'] = namespaced_name
-        return
+def parse_schema(schema, _write_hint=True):
+    if isinstance(schema, dict) and "__fastavro_parsed" in schema:
+        return schema
     else:
-        # dict-y type schema
-        if schema_type in NAMED_TYPES:
-            namespace, name = schema_name(schema, parent_ns)
+        return _parse_schema(schema, "", _write_hint)
 
-            repo[name] = transformer(schema)
 
-        for field in schema.get('fields', []):
-            namespaced_name = extract_named_schemas_into_repo(
-                field['type'],
-                repo,
-                transformer,
+cdef _parse_schema(schema, namespace, _write_hint):
+    # union schemas
+    if isinstance(schema, list):
+        return [_parse_schema(s, namespace, _write_hint) for s in schema]
+
+    # string schemas; this could be either a named schema or a primitive type
+    elif not isinstance(schema, dict):
+        if schema in PRIMITIVES:
+            return schema
+
+        if '.' not in schema and namespace:
+            schema = namespace + '.' + schema
+
+        if schema not in SCHEMA_DEFS:
+            raise UnknownType(schema)
+        else:
+            return schema
+
+    else:
+        # Remaining valid schemas must be dict types
+        schema_type = schema["type"]
+
+        parsed_schema = {
+            key: value
+            for key, value in iteritems(schema)
+            if key not in RESERVED_PROPERTIES
+        }
+        parsed_schema["type"] = schema_type
+
+        if schema_type == "array":
+            parsed_schema["items"] = _parse_schema(
+                schema["items"],
                 namespace,
+                _write_hint
             )
-            if namespaced_name:
-                field['type'] = namespaced_name
+
+        elif schema_type == "map":
+            parsed_schema["values"] = _parse_schema(
+                schema["values"],
+                namespace,
+                _write_hint
+            )
+
+        elif schema_type == "enum":
+            _, fullname = schema_name(schema, namespace)
+            SCHEMA_DEFS[fullname] = schema
+
+            parsed_schema["name"] = fullname
+            parsed_schema["symbols"] = schema["symbols"]
+
+        elif schema_type == "fixed":
+            _, fullname = schema_name(schema, namespace)
+            SCHEMA_DEFS[fullname] = schema
+
+            parsed_schema["name"] = fullname
+            parsed_schema["size"] = schema["size"]
+
+        elif schema_type == "record" or schema_type == "error":
+            # records
+            namespace, fullname = schema_name(schema, namespace)
+            SCHEMA_DEFS[fullname] = schema
+
+            fields = []
+            for field in schema.get('fields', []):
+                fields.append(
+                    parse_field(field, namespace, _write_hint)
+                )
+
+            parsed_schema["name"] = fullname
+            parsed_schema["fields"] = fields
+
+            # Hint that we have parsed the record
+            if _write_hint:
+                parsed_schema["__fastavro_parsed"] = True
+
+        elif schema_type in PRIMITIVES:
+            parsed_schema["type"] = schema_type
+
+        else:
+            raise UnknownType(schema)
+
+        return parsed_schema
+
+
+def parse_field(field, namespace, _write_hint):
+    parsed_field = {
+        "name": field["name"],
+    }
+
+    if "default" in field:
+        parsed_field["default"] = field["default"]
+
+    parsed_field["type"] = _parse_schema(field["type"], namespace, _write_hint)
+
+    return parsed_field
 
 
 def load_schema(schema_path):
@@ -128,8 +169,7 @@ def load_schema(schema_path):
 
 def _load_schema(schema, schema_dir):
     try:
-        from fastavro import acquaint_schema
-        acquaint_schema(schema)
+        return parse_schema(schema)
     except UnknownType as e:
         try:
             avsc = path.join(schema_dir, '%s.avsc' % e.name)
@@ -143,12 +183,3 @@ def _load_schema(schema, schema_dir):
             # schema is already a list
             schema.insert(sub_schema, 0)
             return _load_schema(schema, schema_dir)
-    return schema
-
-
-def populate_schema_defs(schema):
-    extract_named_schemas_into_repo(
-        schema,
-        SCHEMA_DEFS,
-        lambda schema: schema,
-    )

--- a/fastavro/_schema_common.py
+++ b/fastavro/_schema_common.py
@@ -9,22 +9,19 @@ PRIMITIVES = {
     'string',
 }
 
-NAMED_TYPES = {
-    'fixed',
-    'enum',
-    'record',
-    'error',
-}
+# A mapping of named schemas to their actual schema definition
+SCHEMA_DEFS = {}
 
-SCHEMA_DEFS = {
-    'boolean': 'boolean',
-    'bytes': 'bytes',
-    'double': 'double',
-    'float': 'float',
-    'int': 'int',
-    'long': 'long',
-    'null': 'null',
-    'string': 'string',
+RESERVED_PROPERTIES = {
+    'type',
+    'name',
+    'namespace',
+    'fields',  # Record
+    'items',  # Array
+    'size',  # Fixed
+    'symbols',  # Enum
+    'values',  # Map
+    'doc',
 }
 
 

--- a/fastavro/_schema_py.py
+++ b/fastavro/_schema_py.py
@@ -4,8 +4,10 @@ from os import path
 
 import json
 
+from .six import iteritems
 from ._schema_common import (
-    PRIMITIVES, NAMED_TYPES, SCHEMA_DEFS, UnknownType, SchemaParseException
+    PRIMITIVES, UnknownType, SchemaParseException, RESERVED_PROPERTIES,
+    SCHEMA_DEFS,
 )
 
 
@@ -45,71 +47,135 @@ def schema_name(schema, parent_ns):
     if not namespace:
         return namespace, name
 
-    return namespace, '%s.%s' % (namespace, name)
+    return namespace, '{}.{}'.format(namespace, name)
 
 
-def extract_named_schemas_into_repo(schema, repo, transformer, parent_ns=None):
-    if isinstance(schema, list):
-        for index, enum_schema in enumerate(schema):
-            namespaced_name = extract_named_schemas_into_repo(
-                enum_schema,
-                repo,
-                transformer,
-                parent_ns,
-            )
-            if namespaced_name:
-                schema[index] = namespaced_name
-        return
+def parse_schema(schema, _write_hint=True):
+    """Returns a parsed avro schema
 
-    if not isinstance(schema, dict):
-        # If a reference to another schema is an unqualified name, but not one
-        # of the primitive types, then we should add the current enclosing
-        # namespace to reference name.
-        if schema not in PRIMITIVES:
-            if '.' not in schema and parent_ns:
-                schema = parent_ns + '.' + schema
+    It is not necessary to call parse_schema but doing so and saving the parsed
+    schema for use later will make future operations faster as the schema will
+    not need to be reparsed.
 
-            if schema not in repo:
-                raise UnknownType(schema)
+    Parameters
+    ----------
+    schema: dict
+        Input schema
+    _write_hint: bool
+        Internal API argument specifying whether or not the __fastavro_parsed
+        marker should be added to the schema
+
+
+    Example::
+
+        from fastavro import parse_schema
+        from fastavro import writer
+
+        parsed_schema = parse_schema(original_schema)
+        with open('weather.avro', 'wb') as out:
+            writer(out, parsed_schema, records)
+    """
+    if isinstance(schema, dict) and "__fastavro_parsed" in schema:
         return schema
-
-    schema_type = schema.get('type')
-    if schema_type == 'array':
-        namespaced_name = extract_named_schemas_into_repo(
-            schema['items'],
-            repo,
-            transformer,
-            parent_ns,
-        )
-        if namespaced_name:
-            schema['items'] = namespaced_name
-        return
-    elif schema_type == 'map':
-        namespaced_name = extract_named_schemas_into_repo(
-            schema['values'],
-            repo,
-            transformer,
-            parent_ns,
-        )
-        if namespaced_name:
-            schema['values'] = namespaced_name
-        return
     else:
-        # dict-y type schema
-        if schema_type in NAMED_TYPES:
-            namespace, name = schema_name(schema, parent_ns)
+        return _parse_schema(schema, "", _write_hint)
 
-            repo[name] = transformer(schema)
 
-        for field in schema.get('fields', []):
-            namespaced_name = extract_named_schemas_into_repo(
-                field['type'],
-                repo,
-                transformer,
+def _parse_schema(schema, namespace, _write_hint):
+    # union schemas
+    if isinstance(schema, list):
+        return [_parse_schema(s, namespace, _write_hint) for s in schema]
+
+    # string schemas; this could be either a named schema or a primitive type
+    elif not isinstance(schema, dict):
+        if schema in PRIMITIVES:
+            return schema
+
+        if '.' not in schema and namespace:
+            schema = namespace + '.' + schema
+
+        if schema not in SCHEMA_DEFS:
+            raise UnknownType(schema)
+        else:
+            return schema
+
+    else:
+        # Remaining valid schemas must be dict types
+        schema_type = schema["type"]
+
+        parsed_schema = {
+            key: value
+            for key, value in iteritems(schema)
+            if key not in RESERVED_PROPERTIES
+        }
+        parsed_schema["type"] = schema_type
+
+        if schema_type == "array":
+            parsed_schema["items"] = _parse_schema(
+                schema["items"],
                 namespace,
+                _write_hint
             )
-            if namespaced_name:
-                field['type'] = namespaced_name
+
+        elif schema_type == "map":
+            parsed_schema["values"] = _parse_schema(
+                schema["values"],
+                namespace,
+                _write_hint
+            )
+
+        elif schema_type == "enum":
+            _, fullname = schema_name(schema, namespace)
+            SCHEMA_DEFS[fullname] = schema
+
+            parsed_schema["name"] = fullname
+            parsed_schema["symbols"] = schema["symbols"]
+
+        elif schema_type == "fixed":
+            _, fullname = schema_name(schema, namespace)
+            SCHEMA_DEFS[fullname] = schema
+
+            parsed_schema["name"] = fullname
+            parsed_schema["size"] = schema["size"]
+
+        elif schema_type == "record" or schema_type == "error":
+            # records
+            namespace, fullname = schema_name(schema, namespace)
+            SCHEMA_DEFS[fullname] = schema
+
+            fields = []
+            for field in schema.get('fields', []):
+                fields.append(
+                    parse_field(field, namespace, _write_hint)
+                )
+
+            parsed_schema["name"] = fullname
+            parsed_schema["fields"] = fields
+
+            # Hint that we have parsed the record
+            if _write_hint:
+                parsed_schema["__fastavro_parsed"] = True
+
+        elif schema_type in PRIMITIVES:
+            parsed_schema["type"] = schema_type
+
+        else:
+            raise UnknownType(schema)
+
+        return parsed_schema
+
+
+def parse_field(field, namespace, _write_hint):
+    parsed_field = {
+        "name": field["name"],
+    }
+
+    if "default" in field:
+        parsed_field["default"] = field["default"]
+
+    parsed_field["type"] = _parse_schema(field["type"], namespace, _write_hint)
+
+    return parsed_field
 
 
 def load_schema(schema_path):
@@ -128,8 +194,7 @@ def load_schema(schema_path):
 
 def _load_schema(schema, schema_dir):
     try:
-        from fastavro import acquaint_schema
-        acquaint_schema(schema)
+        return parse_schema(schema)
     except UnknownType as e:
         try:
             avsc = path.join(schema_dir, '%s.avsc' % e.name)
@@ -143,12 +208,3 @@ def _load_schema(schema, schema_dir):
             # schema is already a list
             schema.insert(sub_schema, 0)
             return _load_schema(schema, schema_dir)
-    return schema
-
-
-def populate_schema_defs(schema):
-    extract_named_schemas_into_repo(
-        schema,
-        SCHEMA_DEFS,
-        lambda schema: schema,
-    )

--- a/fastavro/_write_py.py
+++ b/fastavro/_write_py.py
@@ -24,10 +24,7 @@ from .const import (
 )
 from .six import utob, MemoryIO, long, iteritems, mk_bits
 from .read import HEADER_SCHEMA, SYNC_SIZE, MAGIC
-from .schema import (
-    extract_named_schemas_into_repo, extract_record_type,
-    extract_logical_type
-)
+from .schema import extract_record_type, extract_logical_type, parse_schema
 from ._schema_common import SCHEMA_DEFS
 from ._timezone import epoch
 
@@ -406,13 +403,15 @@ def write_data(fo, datum, schema):
     record_type = extract_record_type(schema)
     logical_type = extract_logical_type(schema)
 
-    fn = WRITERS[record_type]
-
-    if logical_type:
-        prepare = LOGICAL_WRITERS.get(logical_type)
-        if prepare:
-            datum = prepare(datum, schema)
-    return fn(fo, datum, schema)
+    fn = WRITERS.get(record_type)
+    if fn:
+        if logical_type:
+            prepare = LOGICAL_WRITERS.get(logical_type)
+            if prepare:
+                datum = prepare(datum, schema)
+        return fn(fo, datum, schema)
+    else:
+        return write_data(fo, datum, SCHEMA_DEFS[record_type])
 
 
 def write_header(fo, metadata, sync_marker):
@@ -461,20 +460,6 @@ except ImportError:
     pass
 
 
-def acquaint_schema(schema):
-    """Extract schema into WRITERS"""
-    extract_named_schemas_into_repo(
-        schema,
-        WRITERS,
-        lambda schema: lambda fo, datum, _: write_data(fo, datum, schema),
-    )
-    extract_named_schemas_into_repo(
-        schema,
-        SCHEMA_DEFS,
-        lambda schema: schema,
-    )
-
-
 class Writer(object):
 
     def __init__(self,
@@ -485,7 +470,7 @@ class Writer(object):
                  metadata=None,
                  validator=None):
         self.fo = fo
-        self.schema = schema
+        self.schema = parse_schema(schema)
         self.validate_fn = validate if validator is True else validator
         self.sync_marker = urandom(SYNC_SIZE)
         self.io = MemoryIO()
@@ -501,7 +486,6 @@ class Writer(object):
             raise ValueError('unrecognized codec: %r' % codec)
 
         write_header(self.fo, self.metadata, self.sync_marker)
-        acquaint_schema(self.schema)
 
     def dump(self):
         write_long(self.fo, self.block_count)
@@ -553,10 +537,9 @@ def writer(fo,
         exeption on error.
 
 
-
     Example::
 
-        from fastavro import writer
+        from fastavro import writer, parse_schema
 
         schema = {
             'doc': 'A weather reading.',
@@ -569,6 +552,7 @@ def writer(fo,
                 {'name': 'temp', 'type': 'int'},
             ],
         }
+        parsed_schema = parse_schema(schema)
 
         records = [
             {u'station': u'011990-99999', u'temp': 0, u'time': 1433269388},
@@ -578,7 +562,7 @@ def writer(fo,
         ]
 
         with open('weather.avro', 'wb') as out:
-            writer(out, schema, records)
+            writer(out, parsed_schema, records)
     """
     output = Writer(
         fo,
@@ -607,13 +591,13 @@ def schemaless_writer(fo, schema, record):
         Record to write
 
 
-
     Example::
 
+        parsed_schema = fastavro.parse_schema(schema)
         with open('file.avro', 'rb') as fp:
-            fastavro.schemaless_writer(fp, schema, record)
+            fastavro.schemaless_writer(fp, parsed_schema, record)
 
     Note: The ``schemaless_writer`` can only write a single record.
     """
-    acquaint_schema(schema)
+    schema = parse_schema(schema)
     write_data(fo, record, schema)

--- a/fastavro/read.py
+++ b/fastavro/read.py
@@ -9,8 +9,6 @@ from . import _read_common
 HEADER_SCHEMA = _read_common.HEADER_SCHEMA
 SYNC_SIZE = _read_common.SYNC_SIZE
 MAGIC = _read_common.MAGIC
-acquaint_schema = _read.acquaint_schema
-READERS = _read.READERS
 BLOCK_READERS = _read.BLOCK_READERS
 
 # Public API

--- a/fastavro/schema.py
+++ b/fastavro/schema.py
@@ -9,12 +9,11 @@ from ._schema_common import UnknownType, SchemaParseException
 schema_name = _schema.schema_name
 extract_record_type = _schema.extract_record_type
 extract_logical_type = _schema.extract_logical_type
-populate_schema_defs = _schema.populate_schema_defs
-extract_named_schemas_into_repo = _schema.extract_named_schemas_into_repo
 
 # Public API
 load_schema = _schema.load_schema
+parse_schema = _schema.parse_schema
 
 __all__ = [
-    'UnknownType', 'load_schema', 'SchemaParseException',
+    'UnknownType', 'load_schema', 'SchemaParseException', 'parse_schema',
 ]

--- a/fastavro/write.py
+++ b/fastavro/write.py
@@ -4,9 +4,6 @@ except ImportError as e:
     from . import _write_py as _write
 
 # Private API
-SCHEMA_DEFS = _write.SCHEMA_DEFS
-acquaint_schema = _write.acquaint_schema
-WRITERS = _write.WRITERS
 
 # Public API
 writer = _write.writer

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,23 +2,17 @@ import datetime
 import pytest
 import time
 
-from fastavro.read import READERS
-from fastavro.write import WRITERS
 from fastavro._schema_common import SCHEMA_DEFS
 from fastavro._timezone import utc
 
 
 @pytest.fixture(scope='function')
-def clean_readers_writers_and_schemas():
-    reader_keys = {key for key in READERS.keys()}
-    writer_keys = {key for key in WRITERS.keys()}
+def clean_schemas():
     schema_keys = {key for key in SCHEMA_DEFS.keys()}
 
     yield
 
     repo_keys = (
-        (READERS, reader_keys),
-        (WRITERS, writer_keys),
         (SCHEMA_DEFS, schema_keys),
     )
     for repo, keys in repo_keys:

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -1,8 +1,8 @@
 import pytest
 import fastavro
-from fastavro.schema import SchemaParseException
+from fastavro.schema import SchemaParseException, UnknownType, parse_schema
 
-pytestmark = pytest.mark.usefixtures("clean_readers_writers_and_schemas")
+pytestmark = pytest.mark.usefixtures("clean_schemas")
 
 
 def test_named_types_have_names():
@@ -15,7 +15,7 @@ def test_named_types_have_names():
     }
 
     with pytest.raises(SchemaParseException):
-        fastavro.acquaint_schema(record_schema)
+        fastavro.parse_schema(record_schema)
 
     error_schema = {
         "type": "error",
@@ -26,7 +26,7 @@ def test_named_types_have_names():
     }
 
     with pytest.raises(SchemaParseException):
-        fastavro.acquaint_schema(error_schema)
+        fastavro.parse_schema(error_schema)
 
     fixed_schema = {
         "type": "fixed",
@@ -34,7 +34,7 @@ def test_named_types_have_names():
     }
 
     with pytest.raises(SchemaParseException):
-        fastavro.acquaint_schema(fixed_schema)
+        fastavro.parse_schema(fixed_schema)
 
     enum_schema = {
         "type": "enum",
@@ -42,9 +42,35 @@ def test_named_types_have_names():
     }
 
     with pytest.raises(SchemaParseException):
-        fastavro.acquaint_schema(enum_schema)
+        fastavro.parse_schema(enum_schema)
 
     # Should parse with name
     for schema in (record_schema, error_schema, fixed_schema, enum_schema):
         schema["name"] = "test_named_types_have_names"
-        fastavro.acquaint_schema(schema)
+        fastavro.parse_schema(schema)
+
+
+def test_parse_schema():
+    schema = {
+        "type": "record",
+        "name": "test_parse_schema",
+        "fields": [{
+            "name": "field",
+            "type": "string",
+        }],
+    }
+
+    parsed_schema = parse_schema(schema)
+    assert "__fastavro_parsed" in parsed_schema
+
+    parsed_schema_again = parse_schema(parsed_schema)
+    assert parsed_schema_again == parsed_schema
+
+
+def test_unknown_type():
+    schema = {
+        "type": "unknown",
+    }
+
+    with pytest.raises(UnknownType):
+        parse_schema(schema)

--- a/tests/test_schemaless.py
+++ b/tests/test_schemaless.py
@@ -4,7 +4,7 @@ from fastavro.six import MemoryIO
 
 import pytest
 
-pytestmark = pytest.mark.usefixtures("clean_readers_writers_and_schemas")
+pytestmark = pytest.mark.usefixtures("clean_schemas")
 
 
 def test_schemaless_writer_and_reader():


### PR DESCRIPTION
Not done with this yet, but pretty happy with the results so far. The high level take away is the following:

* `acquaint_schema` is no more
* `parse_schema` has been added
* It's not necessary to call `parse_schema` beforehand, but doing so will make future operations with that parsed schema faster

This PR will replace https://github.com/fastavro/fastavro/pull/214