### PR TITLE
fix issue #248

### DIFF
--- a/fastavro/__init__.py
+++ b/fastavro/__init__.py
@@ -40,7 +40,7 @@ Example usage::
         writer(out, schema, records)
 '''
 
-__version_info__ = (0, 21, 2)
+__version_info__ = (0, 21, 3)
 __version__ = '%s.%s.%s' % __version_info__
 
 

--- a/fastavro/_schema.pyx
+++ b/fastavro/_schema.pyx
@@ -191,5 +191,5 @@ cdef _load_schema(schema, schema_dir):
             return _load_schema([sub_schema, schema], schema_dir)
         else:
             # schema is already a list
-            schema.insert(sub_schema, 0)
+            schema.insert(0, sub_schema)
             return _load_schema(schema, schema_dir)

--- a/fastavro/_schema_py.py
+++ b/fastavro/_schema_py.py
@@ -216,5 +216,5 @@ def _load_schema(schema, schema_dir):
             return _load_schema([sub_schema, schema], schema_dir)
         else:
             # schema is already a list
-            schema.insert(sub_schema, 0)
+            schema.insert(0, sub_schema)
             return _load_schema(schema, schema_dir)

--- a/tests/avro-files/Child1.avsc
+++ b/tests/avro-files/Child1.avsc
@@ -1,0 +1,5 @@
+{
+  "type":"record",
+  "name":"Child1",
+  "fields":[]
+}

--- a/tests/avro-files/Parent.avsc
+++ b/tests/avro-files/Parent.avsc
@@ -1,10 +1,14 @@
 {
-  "type":"record",
-  "name":"Parent",
-  "fields":[
+  "type": "record",
+  "name": "Parent",
+  "fields": [
     {
       "name": "child",
       "type": "Child"
+    },
+    {
+      "name": "child1",
+      "type": "Child1"
     }
   ]
 }

--- a/tests/test_fastavro.py
+++ b/tests/test_fastavro.py
@@ -20,6 +20,7 @@ data_dir = join(abspath(dirname(__file__)), 'avro-files')
 
 try:
     import snappy  # NOQA
+
     has_snappy = True
 except ImportError:
     has_snappy = False
@@ -239,7 +240,7 @@ def test_reading_after_writing_with_load_schema():
     schema_path = join(data_dir, 'Parent.avsc')
     schema = fastavro.schema.load_schema(schema_path)
 
-    records = [{'child': {}}]
+    records = [{'child': {}, 'child1': {}}]
 
     new_file = MemoryIO()
     fastavro.writer(new_file, schema, records)
@@ -248,6 +249,7 @@ def test_reading_after_writing_with_load_schema():
     # Clean the Child and Parent entries so we are forced to get them from the
     # schema
     del SCHEMA_DEFS['Child']
+    del SCHEMA_DEFS['Child1']
     del SCHEMA_DEFS['Parent']
 
     reader = fastavro.reader(new_file)


### PR DESCRIPTION
An `list.insert` call mistake, in '_schema._load_schema' function. Cause error when Parent schema has multiple user-define-type.