### PR TITLE
Fix failure in ValidationError class - Resolves Issue #269

### DIFF
--- a/fastavro/_validate_common.py
+++ b/fastavro/_validate_common.py
@@ -1,7 +1,22 @@
 from collections import namedtuple
 import json
+import sys
 
 
+def python_2_unicode_compatible(klass):
+    """
+    A decorator that defines __unicode__ and __str__ methods under Python 2.
+    Under Python 3 it does nothing.
+    To support Python 2 and 3 with a single code base, define a __str__ method
+    returning text and apply this decorator to the class.
+    """
+    if sys.version_info[0] == 2:
+        klass.__unicode__ = klass.__str__
+        klass.__str__ = lambda self: self.__unicode__().encode('utf-8')
+    return klass
+
+
+@python_2_unicode_compatible
 class ValidationErrorData(namedtuple('ValidationErrorData',
                                      ['datum', 'schema', 'field'])):
     def __str__(self):
@@ -14,8 +29,9 @@ class ValidationErrorData(namedtuple('ValidationErrorData',
             return 'Field({field}) is None' \
                    ' expected {schema}'.format(field=field,
                                                schema=self.schema)
-        return '{field} is <{datum}> of type ' \
-               '{given_type} expected {schema}'. \
+
+        return u'{field} is <{datum}> of type ' \
+               u'{given_type} expected {schema}'. \
             format(datum=self.datum, given_type=type(self.datum),
                    schema=self.schema, field=field)
 

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 from fastavro.validation import (
     ValidationError,
     ValidationErrorData,
@@ -193,6 +194,17 @@ def test_validate_null_in_string_false():
     }]
 
     assert validation_boolean(schema, *records) is False
+
+
+def test_validate_unicode_in_string_does_not_raise():
+    records = [{
+        'str_null': u'日本語',
+        'str': 'str',
+        'integ_null': 21,
+        'integ': 21,
+    }]
+
+    validation_raise(schema, *records)
 
 
 def test_validate_error_raises():


### PR DESCRIPTION
Ensure that in python2.7 only ascii is returned from ValidationErrorData so that str(e) does not fail.


Resolves #269 