### PR TITLE
Bugfix regression since 0.21.7: Allow writing to non-seekable streams again

### DIFF
--- a/fastavro/_six.pyx
+++ b/fastavro/_six.pyx
@@ -47,7 +47,7 @@ if sys.version_info >= (3, 0):
         return datum[0]
 
     def py3_appendable(file_like):
-        if file_like.tell() != 0:
+        if file_like.seekable() and file_like.tell() != 0:
             if file_like.readable():
                 return True
             else:
@@ -112,7 +112,7 @@ else:  # Python 2x
             file_like.mode
         except AttributeError:
             # This is probably some io stream so we rely on its tell() working
-            if file_like.tell() != 0 and _readable(file_like):
+            if file_like.seekable() and file_like.tell() != 0 and _readable(file_like):
                 return True
             else:
                 return False

--- a/fastavro/_six.pyx
+++ b/fastavro/_six.pyx
@@ -112,10 +112,12 @@ else:  # Python 2x
             file_like.mode
         except AttributeError:
             # This is probably some io stream so we rely on its tell() working
-            if file_like.seekable() and file_like.tell() != 0 and _readable(file_like):
-                return True
-            else:
-                return False
+            try:
+                if file_like.tell() != 0 and _readable(file_like):
+                    return True
+            except (OSError, IOError):
+                pass
+            return False
 
         if "a" in file_like.mode:
             if "+" in file_like.mode:

--- a/fastavro/six.py
+++ b/fastavro/six.py
@@ -47,7 +47,7 @@ if sys.version_info >= (3, 0):
         return datum[0]
 
     def py3_appendable(file_like):
-        if file_like.tell() != 0:
+        if file_like.seekable() and file_like.tell() != 0:
             if file_like.readable():
                 return True
             else:

--- a/fastavro/six.py
+++ b/fastavro/six.py
@@ -112,12 +112,12 @@ else:  # Python 2x
             file_like.mode
         except AttributeError:
             # This is probably some io stream so we rely on its tell() working
-            if (file_like.seekable()
-                    and file_like.tell() != 0
-                    and _readable(file_like)):
-                return True
-            else:
-                return False
+            try:
+                if file_like.tell() != 0 and _readable(file_like):
+                    return True
+            except (OSError, IOError):
+                pass
+            return False
 
         if "a" in file_like.mode:
             if "+" in file_like.mode:

--- a/fastavro/six.py
+++ b/fastavro/six.py
@@ -112,7 +112,9 @@ else:  # Python 2x
             file_like.mode
         except AttributeError:
             # This is probably some io stream so we rely on its tell() working
-            if file_like.tell() != 0 and _readable(file_like):
+            if (file_like.seekable()
+                    and file_like.tell() != 0
+                    and _readable(file_like)):
                 return True
             else:
                 return False

--- a/tests/test_fastavro.py
+++ b/tests/test_fastavro.py
@@ -3,7 +3,7 @@ from fastavro.read import _read as _reader
 from fastavro.write import _write as _writer, Writer
 from fastavro._schema_common import SCHEMA_DEFS
 
-from fastavro.six import MemoryIO, appendable
+from fastavro.six import MemoryIO
 
 import pytest
 
@@ -1723,53 +1723,3 @@ def test_appending_records_different_schema_fails(tmpdir):
             fastavro.writer(new_file, different_schema, [{"field": 1}])
 
         assert "does not match file writer_schema" in str(exc)
-
-
-def test_appendable_raises_valuerror(tmpdir):
-    """six.appendable() raises ValueError when file is only 'a' mode."""
-    test_file = str(tmpdir.join("test.avro"))
-
-    with open(test_file, "a") as new_file:
-        new_file.write('this phrase forwards cursor position beyond zero')
-        with pytest.raises(ValueError) as exc:
-            appendable(new_file)
-        assert "you must use the 'a+' mode" in str(exc)
-
-
-def test_appendable_true_nonzero(tmpdir):
-    """six.appendable() returns false when file_like.tell() is non-zero."""
-    test_file = str(tmpdir.join("test.avro"))
-
-    with open(test_file, "a+b") as new_file:
-        new_file.write(b'this phrase forwards cursor position beyond zero')
-        assert appendable(new_file)
-
-
-def test_appendable_false_zero(tmpdir):
-    """six.appendable() returns false when file_like.tell() returns 0."""
-    class MockFileLike:
-        def seekable(self):
-            return True
-
-        def tell(self):
-            # mock a 0 position
-            return 0
-
-    assert not appendable(MockFileLike())
-
-
-def test_appendable_false_unseekable_stream():
-    """File streams that cannot seek return False."""
-
-    class MockFileLike:
-        # This mock file-like object simply returns False for 'seekable', and,
-        # if 'tell' were called, rasies OSError. This mimicks a streaming
-        # buffer like sys.stdout.buffer without actually using it.
-        def seekable(self):
-            return False
-
-        def tell(self):
-            # mock what a write-only stream would do
-            raise OSError(29, "Illegal seek")
-
-    assert not appendable(MockFileLike())

--- a/tests/test_fastavro.py
+++ b/tests/test_fastavro.py
@@ -1750,8 +1750,7 @@ def test_appendable_false_zero(tmpdir):
     test_file = str(tmpdir.join("test.avro"))
 
     with open(test_file, "a+") as new_file:
-        new_file.write('this phrase forwards cursor position beyond zero')
-        assert appendable(new_file)
+        assert not appendable(new_file)
 
 
 def test_appendable_false_unseekable_stream():

--- a/tests/test_fastavro.py
+++ b/tests/test_fastavro.py
@@ -1740,7 +1740,7 @@ def test_appendable_true_nonzero(tmpdir):
     """six.appendable() returns false when file_like.tell() is non-zero."""
     test_file = str(tmpdir.join("test.avro"))
 
-    with open(test_file, "a+") as new_file:
+    with open(test_file, "a+b") as new_file:
         new_file.write('this phrase forwards cursor position beyond zero')
         assert appendable(new_file)
 
@@ -1749,7 +1749,7 @@ def test_appendable_false_zero(tmpdir):
     """six.appendable() returns false when file_like.tell() returns 0."""
     test_file = str(tmpdir.join("test.avro"))
 
-    with open(test_file, "a+") as new_file:
+    with open(test_file, "a+b") as new_file:
         assert not appendable(new_file)
 
 

--- a/tests/test_fastavro.py
+++ b/tests/test_fastavro.py
@@ -1741,13 +1741,16 @@ def test_appendable_true_nonzero(tmpdir):
     test_file = str(tmpdir.join("test.avro"))
 
     with open(test_file, "a+b") as new_file:
-        new_file.write('this phrase forwards cursor position beyond zero')
+        new_file.write(b'this phrase forwards cursor position beyond zero')
         assert appendable(new_file)
 
 
 def test_appendable_false_zero(tmpdir):
     """six.appendable() returns false when file_like.tell() returns 0."""
     class MockFileLike:
+        def seekable(self):
+            return True
+
         def tell(self):
             # mock a 0 position
             return 0

--- a/tests/test_fastavro.py
+++ b/tests/test_fastavro.py
@@ -3,7 +3,7 @@ from fastavro.read import _read as _reader
 from fastavro.write import _write as _writer, Writer
 from fastavro._schema_common import SCHEMA_DEFS
 
-from fastavro.six import MemoryIO
+from fastavro.six import MemoryIO, appendable
 
 import pytest
 
@@ -1723,3 +1723,49 @@ def test_appending_records_different_schema_fails(tmpdir):
             fastavro.writer(new_file, different_schema, [{"field": 1}])
 
         assert "does not match file writer_schema" in str(exc)
+
+
+def test_appendable_raises_valuerror(tmpdir):
+    """six.appendable() raises ValueError when file is only 'a' mode."""
+    test_file = str(tmpdir.join("test.avro"))
+
+    with open(test_file, "a") as new_file:
+        new_file.write('this phrase forwards cursor position beyond zero')
+        with pytest.raises(ValueError) as exc:
+            appendable(new_file)
+        assert "you must use the 'a+' mode" in str(exc)
+
+
+def test_appendable_true_nonzero(tmpdir):
+    """six.appendable() returns false when file_like.tell() is non-zero."""
+    test_file = str(tmpdir.join("test.avro"))
+
+    with open(test_file, "a+") as new_file:
+        new_file.write('this phrase forwards cursor position beyond zero')
+        assert appendable(new_file)
+
+
+def test_appendable_false_zero(tmpdir):
+    """six.appendable() returns false when file_like.tell() returns 0."""
+    test_file = str(tmpdir.join("test.avro"))
+
+    with open(test_file, "a+") as new_file:
+        new_file.write('this phrase forwards cursor position beyond zero')
+        assert appendable(new_file)
+
+
+def test_appendable_false_unseekable_stream():
+    """File streams that cannot seek return False."""
+
+    class MockFileLike:
+        # This mock file-like object simply returns False for 'seekable', and,
+        # if 'tell' were called, rasies OSError. This mimicks a streaming
+        # buffer like sys.stdout.buffer without actually using it.
+        def seekable(self):
+            return False
+
+        def tell(self):
+            # mock what a write-only stream would do
+            raise OSError(29, "Illegal seek")
+
+    assert not appendable(MockFileLike())

--- a/tests/test_fastavro.py
+++ b/tests/test_fastavro.py
@@ -1747,10 +1747,12 @@ def test_appendable_true_nonzero(tmpdir):
 
 def test_appendable_false_zero(tmpdir):
     """six.appendable() returns false when file_like.tell() returns 0."""
-    test_file = str(tmpdir.join("test.avro"))
+    class MockFileLike:
+        def tell(self):
+            # mock a 0 position
+            return 0
 
-    with open(test_file, "a+b") as new_file:
-        assert not appendable(new_file)
+    assert not appendable(MockFileLike())
 
 
 def test_appendable_false_unseekable_stream():

--- a/tests/test_six.py
+++ b/tests/test_six.py
@@ -1,0 +1,52 @@
+import pytest
+from fastavro.six import appendable
+
+
+def test_appendable_raises_valuerror(tmpdir):
+    """six.appendable() raises ValueError when file is only 'a' mode."""
+    test_file = str(tmpdir.join("test.avro"))
+
+    with open(test_file, "a") as new_file:
+        new_file.write('this phrase forwards cursor position beyond zero')
+        with pytest.raises(ValueError) as exc:
+            appendable(new_file)
+        assert "you must use the 'a+' mode" in str(exc)
+
+
+def test_appendable_true_nonzero(tmpdir):
+    """six.appendable() returns True when file_like.tell() is non-zero."""
+    test_file = str(tmpdir.join("test.avro"))
+
+    with open(test_file, "a+b") as new_file:
+        new_file.write(b'this phrase forwards cursor position beyond zero')
+        assert appendable(new_file)
+
+
+def test_appendable_false_zero():
+    """six.appendable() returns True when file_like.tell() returns 0."""
+    class MockFileLike:
+        def seekable(self):
+            return True
+
+        def tell(self):
+            # mock a 0 position
+            return 0
+
+    assert not appendable(MockFileLike())
+
+
+def test_appendable_false_unseekable_stream():
+    """File streams that cannot seek return False."""
+
+    class MockStreamLike:
+        # This mock file-like object simply returns False for 'seekable', and,
+        # if 'tell' were called, rasies OSError. This mimicks a streaming
+        # buffer like sys.stdout.buffer without actually using it.
+        def seekable(self):
+            return False
+
+        def tell(self):
+            # mock what a write-only stream would do
+            raise OSError(29, "Illegal seek")
+
+    assert not appendable(MockStreamLike())

--- a/tox.ini
+++ b/tox.ini
@@ -2,12 +2,7 @@
 envlist = py27,py34,py35,py36,pypy,pypy3,packaging
 
 [testenv]
-deps =
-    pytest
-    flake8
-    check-manifest
-    coverage
-    numpy
+deps = -rdeveloper_requirements.txt
 
 commands = ./run-tests.sh
 

--- a/tox.ini
+++ b/tox.ini
@@ -2,9 +2,15 @@
 envlist = py27,py34,py35,py36,pypy,pypy3,packaging
 
 [testenv]
+setenv =
+    FASTAVRO_USE_CYTHON = 1
 deps =
     pytest
     flake8
+    check-manifest
+    coverage
+    numpy
+
 commands = ./run-tests.sh
 
 [testenv:packaging]

--- a/tox.ini
+++ b/tox.ini
@@ -2,8 +2,6 @@
 envlist = py27,py34,py35,py36,pypy,pypy3,packaging
 
 [testenv]
-setenv =
-    FASTAVRO_USE_CYTHON = 1
 deps =
     pytest
     flake8


### PR DESCRIPTION
commit aaf0242308c4299bb2f8313e9e25485e8f657dfe  introduces a nice new feature to allow to writing to files that were opened in append mode.

However, this directly calls ``tell()`` without concern for whether the stream supports it. For network sockets (not tested), or, especially ``sys.stdout.buffer`` (tested manually), such streams do not have a position, and raise OSError.

We simply guard ourselves from an ``OSError`` by first calling the ``file_like.seekable()`` method in python 3, and expecting possible ``OSError, IOError`` python 2, and raising False in such case. If ``tell()`` raises exception, seek() most certainly will.

I have included simple unit tests that should provide full coverage, and here is example code using ``sys.stdout.buffer`` to write avro directly to stdout, showing how it worked previously (0.21.7), regressed (master), and works again with this PR.

```
import sys, fastavro
schema = {"type": "record", "name": "test_metadata", "fields": []}
fastavro.writer(sys.stdout.buffer, schema, [{}])
```

## Before fix (master) 0.21.10

```
~/Code/fastavro/fastavro/_six.pyx in fastavro._six.py3_appendable()
     48 
     49     def py3_appendable(file_like):
---> 50         if file_like.tell() != 0:
     51             if file_like.readable():
     52                 return True

OSError: [Errno 29] Illegal seek
```

## after fix (branch `suggest-seekable`)

success, writes to stdout:
```
Objavro.codenullavro.schemar{"type": "record", "name": "test_metadata", "fields": []}?`u?.???G?H/??`u?.??G?H/?
```

## from b8b4439

Note this is a regression, version 0.21.7, success, writes to stdout
```
Objavro.codenullavro.schemar{"type": "record", "name": "test_metadata", "fields": []}=�)y:P�=I��.k�=�)y:P�=I��.k�>>> 
```

Thank you for your consideration of this PR!