### PR TITLE
add support for specifying a default value for enums (see AVRO-1340)

### DIFF
--- a/fastavro/_read.pyx
+++ b/fastavro/_read.pyx
@@ -319,9 +319,13 @@ cdef read_enum(fo, writer_schema, reader_schema=None):
     index = read_long(fo)
     symbol = writer_schema['symbols'][index]
     if reader_schema and symbol not in reader_schema['symbols']:
-        symlist = reader_schema['symbols']
-        msg = '%s not found in reader symbol list %s' % (symbol, symlist)
-        raise SchemaResolutionError(msg)
+        default = reader_schema.get("default")
+        if default:
+            return default
+        else:
+            symlist = reader_schema['symbols']
+            msg = '%s not found in reader symbol list %s' % (symbol, symlist)
+            raise SchemaResolutionError(msg)
     return symbol
 
 

--- a/fastavro/_read_py.py
+++ b/fastavro/_read_py.py
@@ -259,9 +259,13 @@ def read_enum(fo, writer_schema, reader_schema=None):
     index = read_long(fo)
     symbol = writer_schema['symbols'][index]
     if reader_schema and symbol not in reader_schema['symbols']:
-        symlist = reader_schema['symbols']
-        msg = '%s not found in reader symbol list %s' % (symbol, symlist)
-        raise SchemaResolutionError(msg)
+        default = reader_schema.get("default")
+        if default:
+            return default
+        else:
+            symlist = reader_schema['symbols']
+            msg = '%s not found in reader symbol list %s' % (symbol, symlist)
+            raise SchemaResolutionError(msg)
     return symbol
 
 

--- a/tests/test_fastavro.py
+++ b/tests/test_fastavro.py
@@ -700,28 +700,6 @@ def test_schema_migration_maps_failure():
         list(new_reader)
 
 
-def test_schema_migration_enum_failure():
-    schema = {
-        "type": "enum",
-        "name": "test",
-        "symbols": ["FOO", "BAR"],
-    }
-
-    new_schema = {
-        "type": "enum",
-        "name": "test",
-        "symbols": ["BAZ", "BAR"],
-    }
-
-    new_file = MemoryIO()
-    records = ["FOO"]
-    fastavro.writer(new_file, schema, records)
-    new_file.seek(0)
-    new_reader = fastavro.reader(new_file, new_schema)
-    with pytest.raises(fastavro.read.SchemaResolutionError):
-        list(new_reader)
-
-
 def test_schema_migration_schema_mismatch():
     schema = {
         "type": "record",


### PR DESCRIPTION
See https://issues.apache.org/jira/browse/AVRO-1340

In Avro 1.9 (whenever it gets released) and enum schema will be able to have a `default` that can be used by the reader schema if the enum that was written doesn't exist in the reader's `symbol` list.