### PR TITLE
Publish wheel for py27mu (in addition to py27m)

### DIFF
--- a/.travis_build_wheel.sh
+++ b/.travis_build_wheel.sh
@@ -10,6 +10,11 @@ TRAVIS_PYTHON_VERSION=${TRAVIS_PYTHON_VERSION/.}
 /opt/python/*${TRAVIS_PYTHON_VERSION}*m/bin/pip install cython
 FASTAVRO_USE_CYTHON=1 /opt/python/*${TRAVIS_PYTHON_VERSION}*m/bin/python setup.py bdist_wheel
 
+# Also produce a wheel for wide-char distributions.
+if ls "/opt/python/*${TRAVIS_PYTHON_VERSION}*mu" &> /dev/null; then
+    FASTAVRO_USE_CYTHON=1 /opt/python/*${TRAVIS_PYTHON_VERSION}*mu/bin/python setup.py bdist_wheel
+fi
+
 # Fix wheel
 for whl in dist/*.whl; do
     auditwheel repair "$whl" -w dist

--- a/publish.sh
+++ b/publish.sh
@@ -19,15 +19,16 @@ OSes="win_amd64
 macosx_10_13_x86_64
 manylinux1_x86_64"
 
-PyVers="27
-34
-35
-36
-37"
+PyVers="27m
+27mu
+34m
+35m
+36m
+37m"
 
 for os in $OSes; do
     for pyver in $PyVers; do
-        wget -q --directory-prefix=dist/ https://github.com/fastavro/fastavro/releases/download/${ver}/fastavro-${ver}-cp${pyver}-cp${pyver}m-${os}.whl
+        wget -q --directory-prefix=dist/ https://github.com/fastavro/fastavro/releases/download/${ver}/fastavro-${ver}-cp${pyver//[!0-9]/}-cp${pyver}-${os}.whl
     done
 done
 


### PR DESCRIPTION
We run `py27mu`, which requires installing via `.tar.gz` (and therefore
all the compilation dependencies are required as well). But we vastly
prefer the speed and simplicity of installing fastavro via wheel.

This change publishes a wheel for `py27mu`.

-----

The full list of distributions currently supported by the manylinux
image is:

```
$ docker run -it quay.io/pypa/manylinux1_x86_64 bash -c "ls /opt/python"
cp27-cp27m  cp27-cp27mu  cp34-cp34m  cp35-cp35m  cp36-cp36m  cp37-cp37m
```

All of these are currently published as wheels with the exception of
`cp27mu`.

I've tested this change by running this invocation from the `.travis.yml`:

```
 $ docker run --rm -v "$(pwd):/data" quay.io/pypa/manylinux1_x86_64 bash -c "/data/.travis_build_wheel.sh 2.7 && ls /data/dist/"
...
fastavro-0.21.14-cp27-cp27m-manylinux1_x86_64.whl
fastavro-0.21.14-cp27-cp27mu-manylinux1_x86_64.whl
```

------

Let me know if there's more I can help with!