### PR TITLE
Add Writer.write_block()

### DIFF
--- a/fastavro/_read.pyx
+++ b/fastavro/_read.pyx
@@ -689,7 +689,7 @@ class Block:
 
     def __str__(self):
         return ("Avro block: %d bytes, %d records, codec: %s, position %d+%d"
-                % (len(self.bytes), self.num_records, self.codec, self.offset,
+                % (len(self.bytes_), self.num_records, self.codec, self.offset,
                    self.size))
 
 

--- a/fastavro/_write.pyx
+++ b/fastavro/_write.pyx
@@ -691,6 +691,16 @@ cdef class Writer(object):
         if self.io.tell() >= self.sync_interval:
             self.dump()
 
+    def write_block(self, block):
+        # Clear existing block if there are any records pending
+        if self.io.tell() or self.block_count > 0:
+            self.dump()
+        cdef bytearray tmp = bytearray()
+        write_long(tmp, block.num_records)
+        self.fo.write(tmp)
+        self.block_writer(self.fo, block.bytes_.getvalue())
+        self.fo.write(self.sync_marker)
+
     def flush(self):
         if self.io.tell() or self.block_count > 0:
             self.dump()

--- a/fastavro/_write_py.py
+++ b/fastavro/_write_py.py
@@ -526,6 +526,14 @@ class Writer(object):
         if self.io.tell() >= self.sync_interval:
             self.dump()
 
+    def write_block(self, block):
+        # Clear existing block if there are any records pending
+        if self.io.tell() or self.block_count > 0:
+            self.dump()
+        write_long(self.fo, block.num_records)
+        self.block_writer(self.fo, block.bytes_.getvalue())
+        self.fo.write(self.sync_marker)
+
     def flush(self):
         if self.io.tell() or self.block_count > 0:
             self.dump()

--- a/tests/test_block_reader.py
+++ b/tests/test_block_reader.py
@@ -96,8 +96,8 @@ def test_block_iteration_memory():
 
 
 def test_block_iteration_deflated_disk():
-    check_round_trip(write_to_disk=True)
+    check_round_trip_deflated(write_to_disk=True)
 
 
 def test_block_iteration_deflated_memory():
-    check_round_trip(write_to_disk=False)
+    check_round_trip_deflated(write_to_disk=False)

--- a/tests/test_write_block.py
+++ b/tests/test_write_block.py
@@ -1,0 +1,75 @@
+import fastavro
+from fastavro.six import MemoryIO
+
+schema = {
+    "type": "record",
+    "name": "test_block_iteration",
+    "fields": [
+        {
+            "name": "nullable_str",
+            "type": ["string", "null"]
+        }, {
+            "name": "str_field",
+            "type": "string"
+        }, {
+            "name": "int_field",
+            "type": "int"
+        }
+    ]
+}
+
+
+def make_records(num_records=2000):
+    return [
+        {
+            "nullable_str": None if i % 3 == 0 else "%d-%d" % (i, i),
+            "str_field": "%d %d %d" % (i, i, i),
+            "int_field": i * 10
+        }
+        for i in range(num_records)
+    ]
+
+
+def make_blocks(num_records=2000, codec='null'):
+    records = make_records(num_records)
+
+    new_file = MemoryIO()
+    fastavro.writer(new_file, schema, records, codec=codec)
+
+    new_file.seek(0)
+    block_reader = fastavro.block_reader(new_file, schema)
+
+    blocks = list(block_reader)
+
+    new_file.close()
+
+    return blocks, records
+
+
+def check_concatenate(source_codec='null', output_codec='null'):
+    blocks1, records1 = make_blocks(codec=source_codec)
+    blocks2, records2 = make_blocks(codec=source_codec)
+
+    new_file = MemoryIO()
+    w = fastavro.write.Writer(new_file, schema, codec=output_codec)
+    for block in blocks1:
+        w.write_block(block)
+    for block in blocks2:
+        w.write_block(block)
+
+    # Read the file back to make sure we get back the same stuff
+    new_file.seek(0)
+    new_records = list(fastavro.reader(new_file, schema))
+    assert new_records == records1 + records2
+
+
+def test_block_concatenation():
+    check_concatenate()
+
+
+def test_block_concatenation_deflated():
+    check_concatenate(source_codec='deflate', output_codec='deflate')
+
+
+def test_block_concatenation_deflated_output():
+    check_concatenate(source_codec='null', output_codec='deflate')

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py34,py35,py36,pypy,pypy3,packaging
+envlist = py27,py34,py35,py36,py37,pypy,pypy3,packaging
 
 [testenv]
 deps = -rdeveloper_requirements.txt


### PR DESCRIPTION
This method is effectively a fast path for writing blocks with a matching schema to an OCF writer.
The primary use cases for this are very fast concatenation and recompressing existing OCF files, or doing both at once which is common in big data scenarios where you might want to combine many small files into one.

This could be additionally be exposed as a `block_writer` interface similar to `block_reader`

Note I have not added any safety checks as the system we are using this in already hashes the schemas of incoming OCF files before concatenating them but a similar approach could be added to the library (or warning labels added) - figured I would ask what you prefer.

Additionally this fixes up some small issues in separate commits, if you prefer I can move those into a different PR.