### PR TITLE
do not write the hint to the datafile

### DIFF
--- a/fastavro/_write.pyx
+++ b/fastavro/_write.pyx
@@ -664,6 +664,14 @@ cdef class Writer(object):
 
             self.metadata = metadata or {}
             self.metadata['avro.codec'] = codec
+
+            if isinstance(schema, dict):
+                schema = {
+                    key: value
+                    for key, value in iteritems(schema)
+                    if key != "__fastavro_parsed"
+                }
+
             self.metadata['avro.schema'] = json.dumps(schema)
 
             try:

--- a/fastavro/_write_py.py
+++ b/fastavro/_write_py.py
@@ -501,6 +501,14 @@ class Writer(object):
 
             self.metadata = metadata or {}
             self.metadata['avro.codec'] = codec
+
+            if isinstance(schema, dict):
+                schema = {
+                    key: value
+                    for key, value in iteritems(schema)
+                    if key != "__fastavro_parsed"
+                }
+
             self.metadata['avro.schema'] = json.dumps(schema)
 
             try:

--- a/tests/test_fastavro.py
+++ b/tests/test_fastavro.py
@@ -1837,3 +1837,25 @@ def test_writer_schema_always_read():
 
     # This should not raise a KeyError
     fastavro.reader(file)
+
+
+def test_hint_is_not_written_to_the_file():
+    """The __fastavro_parsed hint should not be written to the avrofile"""
+    schema = {
+        "type": "record",
+        "name": "test_hint_is_not_written_to_the_file",
+        "fields": []
+    }
+
+    parsed_schema = fastavro.parse_schema(schema)
+
+    # It should get added when parsing
+    assert "__fastavro_parsed" in parsed_schema
+
+    stream = MemoryIO()
+    fastavro.writer(stream, parsed_schema, [{}])
+    stream.seek(0)
+
+    reader = fastavro.reader(stream)
+    # By the time it is in the file, it should not
+    assert "__fastavro_parsed" not in reader._schema


### PR DESCRIPTION
This hopefully resolves [the issue raised in passing here](https://github.com/fastavro/fastavro/issues/312#issue-402769560) which is that we shouldn't be writing `__fastavro_parsed` to the datafile.