### PR TITLE
Fix Mac OSX Streaming output to sys.stdout.buffer (Closes #330).

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,6 @@
+2019-05-27 version 0.21.24
+* Allow streaming to sys.stdout.buffer on OSX without raising ValueError (@jquast in PR #342)
+
 2019-05-06 version 0.21.23
 * Accept an ISO Date as a string (@scottbelden in PR #338)
 * Fix failure case involving unions and nulls (@scottbelden in PR #337)

--- a/fastavro/__init__.py
+++ b/fastavro/__init__.py
@@ -40,7 +40,7 @@ Example usage::
         writer(out, schema, records)
 '''
 
-__version_info__ = (0, 21, 23)
+__version_info__ = (0, 21, 24)
 __version__ = '%s.%s.%s' % __version_info__
 
 

--- a/fastavro/__main__.py
+++ b/fastavro/__main__.py
@@ -90,6 +90,7 @@ def main(argv=None):
                 _clean_json_record(record)
                 json_dump(record, indent)
                 sys.stdout.write('\n')
+                sys.stdout.flush()
         except (IOError, KeyboardInterrupt):
             pass
 

--- a/fastavro/_six.pyx
+++ b/fastavro/_six.pyx
@@ -6,7 +6,6 @@
 Some of this code is "lifted" from CherryPy.
 '''
 import sys
-from sys import stdout
 from struct import unpack
 
 import json
@@ -24,7 +23,7 @@ if sys.version_info >= (3, 0):
         return bytes(n, encoding)
 
     def py3_json_dump(obj, indent):
-        json.dump(obj, stdout, indent=indent)
+        json.dump(obj, sys.stdout, indent=indent)
 
     def py3_iterkeys(obj):
         return obj.keys()
@@ -48,7 +47,13 @@ if sys.version_info >= (3, 0):
         return datum[0]
 
     def py3_appendable(file_like):
-        if file_like.seekable() and file_like.tell() != 0:
+        # in addition to "are you seekable?" and "do you know your position?"
+        # we also do this direct identity comparison of 'file_like' vs.
+        # sys.stdout.buffer, this works around a strange discovery of OSX
+        # Platform, that stdout.buffer *is* seekable, and *does* know its
+        # position, strange!
+        if (file_like.seekable() and file_like.tell() != 0
+                and file_like is not sys.stdout.buffer):
             if file_like.readable():
                 return True
             else:
@@ -69,13 +74,13 @@ else:  # Python 2x
     def py2_utob(n, encoding=_encoding):
         return n.encode(encoding)
 
-    _outenc = getattr(stdout, 'encoding', None) or _encoding
+    _outenc = getattr(sys.stdout, 'encoding', None) or _encoding
 
     def py2_json_dump(obj, indent):
         kwargs = {}
         if indent is not None:
             kwargs['indent'] = indent
-        json.dump(obj, stdout, encoding=_outenc, **kwargs)
+        json.dump(obj, sys.stdout, encoding=_outenc, **kwargs)
 
     def py2_iterkeys(obj):
         return obj.iterkeys()

--- a/fastavro/six.py
+++ b/fastavro/six.py
@@ -5,7 +5,6 @@
 Some of this code is "lifted" from CherryPy.
 '''
 import sys
-from sys import stdout
 from struct import unpack
 
 import json
@@ -23,7 +22,7 @@ if sys.version_info >= (3, 0):
         return bytes(n, encoding)
 
     def py3_json_dump(obj, indent):
-        json.dump(obj, stdout, indent=indent)
+        json.dump(obj, sys.stdout, indent=indent)
 
     def py3_iterkeys(obj):
         return obj.keys()
@@ -47,7 +46,13 @@ if sys.version_info >= (3, 0):
         return datum[0]
 
     def py3_appendable(file_like):
-        if file_like.seekable() and file_like.tell() != 0:
+        # in addition to "are you seekable?" and "do you know your position?"
+        # we also do this direct identity comparison of 'file_like' vs.
+        # sys.stdout.buffer, this works around a strange discovery of OSX
+        # Platform, that stdout.buffer *is* seekable, and *does* know its
+        # position, strange!
+        if (file_like.seekable() and file_like.tell() != 0
+                and file_like is not sys.stdout.buffer):
             if file_like.readable():
                 return True
             else:
@@ -68,13 +73,13 @@ else:  # Python 2x
     def py2_utob(n, encoding=_encoding):
         return n.encode(encoding)
 
-    _outenc = getattr(stdout, 'encoding', None) or _encoding
+    _outenc = getattr(sys.stdout, 'encoding', None) or _encoding
 
     def py2_json_dump(obj, indent):
         kwargs = {}
         if indent is not None:
             kwargs['indent'] = indent
-        json.dump(obj, stdout, encoding=_outenc, **kwargs)
+        json.dump(obj, sys.stdout, encoding=_outenc, **kwargs)
 
     def py2_iterkeys(obj):
         return obj.iterkeys()

--- a/tests/test_six.py
+++ b/tests/test_six.py
@@ -1,3 +1,4 @@
+import sys
 import pytest
 from fastavro.six import appendable
 
@@ -50,3 +51,13 @@ def test_appendable_false_unseekable_stream():
             raise OSError(29, "Illegal seek")
 
     assert not appendable(MockStreamLike())
+
+
+def test_appendable_false_stdout(capfd):
+    """six.appendable() returns False when file_like is sys.stdout.buffer."""
+    # normally, pytest performs "Capturing of stderr/stdout", which is pretty
+    # great, but it impacts this "integration test": we'd like to use our true
+    # stdout, whether it is a terminal or pipe, to invoke the true behavior of
+    # appendable() when used with 'sys.stdout.buffer'.
+    with capfd.disabled():
+        assert not appendable(sys.stdout.buffer)

--- a/tests/test_six.py
+++ b/tests/test_six.py
@@ -60,4 +60,7 @@ def test_appendable_false_stdout(capfd):
     # stdout, whether it is a terminal or pipe, to invoke the true behavior of
     # appendable() when used with 'sys.stdout.buffer'.
     with capfd.disabled():
-        assert not appendable(sys.stdout.buffer)
+        if sys.version_info >= (3, 0):
+            assert not appendable(sys.stdout.buffer)
+        else:
+            assert not appendable(sys.stdout)

--- a/tests/test_write_block.py
+++ b/tests/test_write_block.py
@@ -1,5 +1,9 @@
+# local
 import fastavro
 from fastavro.six import MemoryIO
+
+# 3rd party
+import pytest
 
 schema = {
     "type": "record",
@@ -46,7 +50,14 @@ def make_blocks(num_records=2000, codec='null'):
     return blocks, records
 
 
-def check_concatenate(source_codec='null', output_codec='null'):
+@pytest.mark.parametrize(
+    "source_codec,output_codec", [
+        ('null', 'null'),
+        ('deflate', 'deflate'),
+        ('null', 'deflate'),
+        ('deflate', 'null'),
+    ])
+def test_check_concatenate(source_codec, output_codec):
     blocks1, records1 = make_blocks(codec=source_codec)
     blocks2, records2 = make_blocks(codec=source_codec)
 
@@ -61,15 +72,3 @@ def check_concatenate(source_codec='null', output_codec='null'):
     new_file.seek(0)
     new_records = list(fastavro.reader(new_file, schema))
     assert new_records == records1 + records2
-
-
-def test_block_concatenation():
-    check_concatenate()
-
-
-def test_block_concatenation_deflated():
-    check_concatenate(source_codec='deflate', output_codec='deflate')
-
-
-def test_block_concatenation_deflated_output():
-    check_concatenate(source_codec='null', output_codec='deflate')


### PR DESCRIPTION
- Create a TDD in ``tests/test_six.py``, where it is necessary to temporarily
  disable pytest's 'capfd' method, https://docs.pytest.org/en/latest/capture.html
- This test then fails, raising ValueError on OSX, and fixed by ``is sys.stdout`` identity check.
- To support this test, lazily bind to sys.stdout object reference in ``six.py`` (and ``_six.pyx``), we want sys.stdout reference at runtime rather than import, because we would otherwise get a handle of the "capfd" (file-like) stdout from pytest, even after disabling it our test.
- Unrelated but fun, use ``pytest.mark.parameterize()`` in ``tests/test_write_block.py``

Closes #330 