### PR TITLE
Fix snappy block reader

### DIFF
--- a/fastavro/_read_py.py
+++ b/fastavro/_read_py.py
@@ -471,10 +471,10 @@ BLOCK_READERS = {
 }
 
 
-def snappy_read_block(fo):
-    length = read_long(fo)
-    data = fo.read(length - 4)
-    fo.read(4)  # CRC
+def snappy_read_block(decoder):
+    length = read_long(decoder)
+    data = decoder.read_fixed(length - 4)
+    decoder.read_fixed(4)  # CRC
     return MemoryIO(snappy.decompress(data))
 
 


### PR DESCRIPTION
Resolves https://github.com/fastavro/fastavro/issues/345

- Snappy expects to get a file that has method
  `read` but actually gets passed a decoder that
  has no generic `read` method
- Fix is to change `read` to `read_fixed`