### PR TITLE
Optimize read - decimal, logical type

### DIFF
--- a/fastavro/_read.pyx
+++ b/fastavro/_read.pyx
@@ -10,7 +10,7 @@
 import bz2
 import zlib
 import datetime
-from decimal import localcontext, Decimal
+from decimal import Context
 from fastavro.six import MemoryIO
 from uuid import UUID
 
@@ -52,6 +52,8 @@ AVRO_TYPES = {
     'request',
     'error_union'
 }
+
+decimal_context = Context()
 
 
 ctypedef int int32
@@ -183,10 +185,9 @@ cpdef read_decimal(data, writer_schema=None, reader_schema=None):
 
     unscaled_datum = be_signed_bytes_to_int(data)
 
-    with localcontext() as ctx:
-        ctx.prec = precision
-        scaled_datum = Decimal(unscaled_datum).scaleb(-scale)
-    return scaled_datum
+    decimal_context.prec = precision
+    return decimal_context.create_decimal(unscaled_datum).\
+        scaleb(-scale, decimal_context)
 
 
 cdef long64 read_long(fo,
@@ -499,7 +500,6 @@ cpdef _read_data(fo, writer_schema, reader_schema=None):
     """Read data from file object according to schema."""
 
     record_type = extract_record_type(writer_schema)
-    logical_type = extract_logical_type(writer_schema)
 
     if reader_schema and record_type in AVRO_TYPES:
         # If the schemas are the same, set the reader schema to None so that no
@@ -546,6 +546,7 @@ cpdef _read_data(fo, writer_schema, reader_schema=None):
         raise EOFError('cannot read %s from %s' % (record_type, fo))
 
     if 'logicalType' in writer_schema:
+        logical_type = extract_logical_type(writer_schema)
         fn = LOGICAL_READERS.get(logical_type)
         if fn:
             return fn(data, writer_schema, reader_schema)


### PR DESCRIPTION
Hello,
performance of `fastavro` is critical to us because we are using `avro` as the main transport protocol. It seems that serialization/deserialization is our bottleneck right now. I profiled the code a little and noticed that `read_decimal` takes substantial time (we use decimal a lot). So this is my attempt to improve the speed. I used a pre-made `decimal_context` because the context manager is too demanding. This made the function twice faster.
I also noticed that `extract_record_type` and `extract_logical_type` is called a lot. I didn't find a way how to speed up `extract_record_type` but at least I moved `extract_logical_type` to the branch where it is really needed and saves a few useless calls.
This is just a minor change but improved the speed of decoding on my data (array of unions of dicts with a lot of decimals) by 15 %.