### PR TITLE
pre-epoch timestamps on windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ venv
 .tox
 .idea
 *.pyc
+*.pyd
 .cache/
 .pytest_cache/
 .eggs/

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,4 @@
-include README.md ChangeLog *.sh
+include README.md ChangeLog *.sh *.cmd
 include Makefile
 include *.txt
 include tox.ini

--- a/README.md
+++ b/README.md
@@ -70,7 +70,9 @@ If those are installed, you can run the tests with `./run-tests.sh`. If you have
 installing those dependencies, you can run `docker build .` to run the tests inside
 a docker container. This won't test on all versions of python or on pypy, so it's possible
 to still get CI failures after making a pull request, but we can work through those errors
-if/when they happen.
+if/when they happen. `.run-tests.sh` only covers the Cython tests. In order to test the
+pure Python implementation, comment out `FASTAVRO_USE_CYTHON=1 python setup.py build_ext --inplace`
+and re-run.
 
 ### Releasing
 

--- a/fastavro/_logical_writers.pyx
+++ b/fastavro/_logical_writers.pyx
@@ -99,7 +99,7 @@ cpdef prepare_timestamp_micros(object data, schema):
                         <object>(data - epoch_naive).total_seconds()) * MCS_PER_SECOND
                     )
             else:
-                return <long64>(<double>(data.timestamp()) * MLS_PER_SECOND)
+                return <long64>(<double>(data.timestamp()) * MCS_PER_SECOND)
     else:
         return data
 

--- a/fastavro/_logical_writers.pyx
+++ b/fastavro/_logical_writers.pyx
@@ -3,6 +3,7 @@
 import datetime
 
 import decimal
+import os
 import uuid
 
 from libc.time cimport tm, mktime
@@ -11,7 +12,7 @@ from cpython.tuple cimport PyTuple_GET_ITEM
 
 from fastavro import const
 from ._six import long, mk_bits, int_to_be_signed_bytes
-from ._timezone import epoch
+from ._timezone import epoch, epoch_naive
 
 ctypedef long long long64
 
@@ -23,6 +24,7 @@ cdef long64 MLS_PER_SECOND = const.MLS_PER_SECOND
 cdef long64 MLS_PER_MINUTE = const.MLS_PER_MINUTE
 cdef long64 MLS_PER_HOUR = const.MLS_PER_HOUR
 
+cdef is_windows = os.name == 'nt'
 
 # The function datetime.timestamp() is a simpler, faster way to convert a
 # datetime to a Unix timestamp, but is only available in Python 3.3 and later.
@@ -33,6 +35,7 @@ cpdef prepare_timestamp_millis(object data, schema):
     cdef object tt
     cdef tm time_tuple
     if isinstance(data, datetime.datetime):
+        print(f'date: {data}')
         if not has_timestamp_fn:
             if data.tzinfo is not None:
                 return <long64>(<double>(
@@ -50,7 +53,17 @@ cpdef prepare_timestamp_millis(object data, schema):
             return mktime(& time_tuple) * MLS_PER_SECOND + <long64>(
                 int(data.microsecond) / 1000)
         else:
-            return <long64>(<double>(data.timestamp()) * MLS_PER_SECOND)
+            if is_windows:
+                if data.tzinfo is not None:
+                    return <long64>(<double>(
+                        <object>(data - epoch).total_seconds()) * MLS_PER_SECOND
+                    )
+                else:
+                    return <long64>(<double>(
+                        <object>(data - epoch_naive).total_seconds()) * MLS_PER_SECOND
+                    )
+            else:
+                return <long64>(<double>(data.timestamp()) * MLS_PER_SECOND)
     else:
         return data
 
@@ -76,7 +89,17 @@ cpdef prepare_timestamp_micros(object data, schema):
             return mktime(& time_tuple) * MCS_PER_SECOND + \
                 <long64>(data.microsecond)
         else:
-            return <long64>(<double>(data.timestamp()) * MCS_PER_SECOND)
+            if is_windows:
+                if data.tzinfo is not None:
+                    return <long64>(<double>(
+                        <object>(data - epoch).total_seconds()) * MCS_PER_SECOND
+                    )
+                else:
+                    return <long64>(<double>(
+                        <object>(data - epoch_naive).total_seconds()) * MCS_PER_SECOND
+                    )
+            else:
+                return <long64>(<double>(data.timestamp()) * MLS_PER_SECOND)
     else:
         return data
 

--- a/fastavro/_logical_writers.pyx
+++ b/fastavro/_logical_writers.pyx
@@ -35,7 +35,6 @@ cpdef prepare_timestamp_millis(object data, schema):
     cdef object tt
     cdef tm time_tuple
     if isinstance(data, datetime.datetime):
-        print(f'date: {data}')
         if not has_timestamp_fn:
             if data.tzinfo is not None:
                 return <long64>(<double>(
@@ -53,6 +52,8 @@ cpdef prepare_timestamp_millis(object data, schema):
             return mktime(& time_tuple) * MLS_PER_SECOND + <long64>(
                 int(data.microsecond) / 1000)
         else:
+            # On Windows, timestamps before the epoch will raise an error.
+            # See https://bugs.python.org/issue36439
             if is_windows:
                 if data.tzinfo is not None:
                     return <long64>(<double>(
@@ -89,6 +90,8 @@ cpdef prepare_timestamp_micros(object data, schema):
             return mktime(& time_tuple) * MCS_PER_SECOND + \
                 <long64>(data.microsecond)
         else:
+            # On Windows, timestamps before the epoch will raise an error.
+            # See https://bugs.python.org/issue36439
             if is_windows:
                 if data.tzinfo is not None:
                     return <long64>(<double>(

--- a/fastavro/_read.pyx
+++ b/fastavro/_read.pyx
@@ -24,7 +24,7 @@ from ._schema_common import SCHEMA_DEFS
 from ._read_common import (
     SchemaResolutionError, MAGIC, SYNC_SIZE, HEADER_SCHEMA, missing_codec_lib
 )
-from ._timezone import utc
+from ._timezone import epoch
 from .const import (
     MCS_PER_HOUR, MCS_PER_MINUTE, MCS_PER_SECOND, MLS_PER_HOUR, MLS_PER_MINUTE,
     MLS_PER_SECOND, DAYS_SHIFT
@@ -144,7 +144,7 @@ cdef inline read_boolean(fo, writer_schema=None, reader_schema=None):
 
 
 cpdef parse_timestamp(data, resolution):
-    return datetime.datetime.fromtimestamp(data / resolution, tz=utc)
+    return epoch + datetime.timedelta(seconds=data / resolution)
 
 
 cpdef read_timestamp_millis(data, writer_schema=None, reader_schema=None):

--- a/fastavro/_read_py.py
+++ b/fastavro/_read_py.py
@@ -26,7 +26,7 @@ from ._schema_common import SCHEMA_DEFS
 from ._read_common import (
     SchemaResolutionError, MAGIC, SYNC_SIZE, HEADER_SCHEMA, missing_codec_lib
 )
-from ._timezone import utc
+from ._timezone import epoch
 from .const import (
     MCS_PER_HOUR, MCS_PER_MINUTE, MCS_PER_SECOND, MLS_PER_HOUR, MLS_PER_MINUTE,
     MLS_PER_SECOND, DAYS_SHIFT
@@ -122,7 +122,7 @@ def read_boolean(decoder, writer_schema=None, reader_schema=None):
 
 
 def parse_timestamp(data, resolution):
-    return datetime.datetime.fromtimestamp(data / resolution, tz=utc)
+    return epoch + datetime.timedelta(seconds=data / resolution)
 
 
 def read_timestamp_millis(data, writer_schema=None, reader_schema=None):

--- a/fastavro/_timezone.py
+++ b/fastavro/_timezone.py
@@ -23,3 +23,4 @@ utc = UTCTzinfo()
 # used to compute timestamp for tz-aware datetime objects
 # python >= 3.3 can use datetime.datetime.timestamp() instead
 epoch = datetime(1970, 1, 1, tzinfo=utc)
+epoch_naive = datetime(1970, 1, 1)

--- a/run-tests.cmd
+++ b/run-tests.cmd
@@ -1,0 +1,21 @@
+@echo off
+setlocal
+
+for /F "tokens=* USEBACKQ" %%F in (`python --version 2^>^&1`) do set PYTHON_VERSION=%%F
+echo [%date%:%time%] %USERNAME% :: %PYTHON_VERSION%
+
+del /S *.pyc
+del /S *.pyd
+
+echo "running flake8"
+flake8 fastavro tests
+flake8 --config=.flake8.cython fastavro
+
+check-manifest
+
+set FASTAVRO_USE_CYTHON=1
+python setup.py build_ext --inplace
+
+set PYTHONPATH=%cd%
+python -m pytest --cov=fastavro -v --cov-report=term-missing --cov-report=html:build/htmlcov tests
+endlocal

--- a/tests/test_logical_types.py
+++ b/tests/test_logical_types.py
@@ -137,26 +137,25 @@ def test_not_null_date():
     assert (data2['date'] == datetime.date(2017, 1, 1))
 
 
-schema_datetime = {
-    "fields": [
-        {
-            "name": "timestamp-millis",
-            "type": {'type': 'long', 'logicalType': 'timestamp-millis'}
-        },
-        {
-            "name": "timestamp-micros",
-            "type": {'type': 'long', 'logicalType': 'timestamp-micros'}
-        }
-    ],
-    "namespace": "namespace",
-    "name": "name",
-    "type": "record"
-}
-
-
 # particularly critical on Windows
 # see https://github.com/fastavro/fastavro/issues/389
 def test_ancient_datetime():
+    schema_datetime = {
+        "fields": [
+            {
+                "name": "timestamp-millis",
+                "type": {'type': 'long', 'logicalType': 'timestamp-millis'}
+            },
+            {
+                "name": "timestamp-micros",
+                "type": {'type': 'long', 'logicalType': 'timestamp-micros'}
+            }
+        ],
+        "namespace": "namespace",
+        "name": "name",
+        "type": "record"
+    }
+
     data1 = {
         'timestamp-millis': datetime.datetime(1960, 1, 1),
         'timestamp-micros': datetime.datetime(1960, 1, 1)

--- a/tests/test_logical_types.py
+++ b/tests/test_logical_types.py
@@ -137,6 +137,39 @@ def test_not_null_date():
     assert (data2['date'] == datetime.date(2017, 1, 1))
 
 
+schema_datetime = {
+    "fields": [
+        {
+            "name": "timestamp-millis",
+            "type": {'type': 'long', 'logicalType': 'timestamp-millis'}
+        },
+        {
+            "name": "timestamp-micros",
+            "type": {'type': 'long', 'logicalType': 'timestamp-micros'}
+        }
+    ],
+    "namespace": "namespace",
+    "name": "name",
+    "type": "record"
+}
+
+
+# particularly critical on Windows
+# see https://github.com/fastavro/fastavro/issues/389
+def test_ancient_datetime():
+    data1 = {
+        'timestamp-millis': datetime.datetime(1960, 1, 1),
+        'timestamp-micros': datetime.datetime(1960, 1, 1)
+    }
+    binary = serialize(schema_datetime, data1)
+    data2 = deserialize(schema_datetime, binary)
+
+    assert data1['timestamp-millis'] == data2['timestamp-millis'].replace(
+        tzinfo=None)
+    assert data1['timestamp-micros'] == data2['timestamp-micros'].replace(
+        tzinfo=None)
+
+
 # test bytes decimal
 schema_bytes_decimal = {
     "name": "n",


### PR DESCRIPTION
Works fine on Windows and Python 3.7. There is still an issue with 2.7, when it hits https://github.com/fastavro/fastavro/blob/master/fastavro/_logical_writers.pyx#L41 - which would need a similar fix. We don't support 2.7 anymore, though, so would prefer to fix separately to avoid risk.

Tested successfully on Linux and Python 2.7 and 3.7.
It does feel a bit awkward, so happy to discuss if you see any improvements.