### PR TITLE
fix: allow run pytests with arguments.

### DIFF
--- a/run-tests.sh
+++ b/run-tests.sh
@@ -19,4 +19,4 @@ check-manifest
 FASTAVRO_USE_CYTHON=1 python setup.py build_ext --inplace
 pip install -e .
 
-PYTHONPATH=${PWD} python -m pytest --cov=fastavro -v --cov-report=term-missing --cov-report=html:build/htmlcov $@ tests
+PYTHONPATH=${PWD} python -m pytest --cov=fastavro -v --cov-report=term-missing --cov-report=html:build/htmlcov $@


### PR DESCRIPTION
This `PR` allows to run specific tests, by default run all tests

```bash
# run all tests
./run-tests.sh

# run specific tests
./run-tests.sh tests/test_compression.py::test_optional_codecs
```