### PR TITLE
fix error writing json with dependent schemas (#418)

### DIFF
--- a/fastavro/io/parser.py
+++ b/fastavro/io/parser.py
@@ -5,6 +5,7 @@ from .symbols import (
     EnumLabels, Fixed, ArrayStart, ArrayEnd, ItemEnd,
 )
 from ..schema import extract_record_type
+from .._schema_common import SCHEMA_DEFS
 
 
 class Parser:
@@ -91,6 +92,8 @@ class Parser:
             return Double()
         elif record_type == "fixed":
             return Fixed()
+        elif record_type in SCHEMA_DEFS:
+            return self._parse(SCHEMA_DEFS[record_type])
         else:
             raise Exception("Unhandled type: {}".format(record_type))
 

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -1,4 +1,5 @@
 from fastavro import json_writer, json_reader
+from fastavro.schema import parse_schema
 from fastavro.six import StringIO
 
 import json
@@ -448,6 +449,47 @@ def test_union_in_map():
             'd': None
         }
     }]
+
+    new_records = roundtrip(schema, records)
+    assert records == new_records
+
+
+def test_with_dependent_schema():
+    """Tests a schema with dependent schema
+    https://github.com/fastavro/fastavro/issues/418"""
+    dependency = {
+        "type": "record",
+        "name": "Dependency",
+        "namespace": "test",
+        "fields": [{
+            "name": "_name",
+            "type": "string"
+        }]
+    }
+
+    schema = {
+        "type": "record",
+        "name": "Test",
+        "namespace": "test",
+        "fields": [{
+            "name": "_name",
+            "type": "string"
+
+        }, {
+            "name": "_dependency",
+            "type": "Dependency"
+        }]
+    }
+
+    records = [{
+        '_name': 'parent',
+        '_dependency': {
+            '_name': 'child'
+        }
+    }]
+
+    parse_schema(dependency, "/tmp/dir")
+    parse_schema(schema, "/tmp/dir")
 
     new_records = roundtrip(schema, records)
     assert records == new_records

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -489,7 +489,7 @@ def test_with_dependent_schema():
     }]
 
     parse_schema(dependency)
-    parse_schema(schema, "/tmp/dir")
+    parse_schema(schema)
 
     new_records = roundtrip(schema, records)
     assert records == new_records

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -488,7 +488,7 @@ def test_with_dependent_schema():
         }
     }]
 
-    parse_schema(dependency, "/tmp/dir")
+    parse_schema(dependency)
     parse_schema(schema, "/tmp/dir")
 
     new_records = roundtrip(schema, records)


### PR DESCRIPTION
- Add a check for known schema types to `parser.py`.
- Add a test to `test_json.py` that tests writing a record to json with a schema that includes a dependency on another known schema.