### PR TITLE
Minor testing tweaks

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,8 +12,8 @@ def look_for_cython_error(capfd):
     will usually print a message to stderr saying that an exception was
     ignored. Here we check for that in every test function."""
     yield
-    captured = capfd.readouterr()
-    assert "Exception ignored" not in captured.err
+    _, err = capfd.readouterr()
+    assert "Exception ignored" not in err
 
 
 @pytest.fixture(scope='function')


### PR DESCRIPTION
I've been working on adding several features to fastavro (more PRs to come) and encountered a couple minor inconveniences.

The teardown was failing with AttributeError on captured.err. Not sure why, but treating it as a tuple fixed the problem.

The pandas change is just a quality of life improvement, skipping instead of failing the test for optional functionality.