### PR TITLE
Add missing fastavro/_logical_writers.c to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ endif
 %.c: %.pyx
 	cython $(<D)/$(<F)
 
-c_files = fastavro/_six.c fastavro/_read.c fastavro/_write.c fastavro/_schema.c fastavro/_validation.c
+c_files = fastavro/_six.c fastavro/_read.c fastavro/_write.c fastavro/_schema.c fastavro/_validation.c fastavro/_logical_writers.c
 
 all: $(c_files)
 


### PR DESCRIPTION
This looks to be a trivial oversight from a refactoring, as far as I can tell.