### PR TITLE
Special handling for unions containing both float and double

### DIFF
--- a/fastavro/_schema.pyx
+++ b/fastavro/_schema.pyx
@@ -67,14 +67,37 @@ def parse_schema(schema, expand=False, _write_hint=True, _force=False):
         return _parse_schema(schema, "", expand, _write_hint, set())
 
 
+cdef _reorder_float_unions(schema):
+    """Re-orders union types containing both "float" and "double",
+    so that "double" is preferred and no precision is lost when writing
+    64 bit python floats to ["float", "double"] union types
+    """
+
+    left = []
+    right = []
+
+    for sub in schema:
+        if sub == "float" or (hasattr(sub, "get") and sub.get("type") == "float"):
+            right.append(sub)
+        elif sub == "double" or (hasattr(sub, "get") and sub.get("type") == "double"):
+            left.append(sub)
+        else:
+            if len(right) == 0:
+                left.append(sub)
+            else:
+                right.append(sub)
+
+    return left + right
+
+
 cdef _parse_schema(schema, namespace, expand, _write_hint, named_schemas):
     # union schemas
     if isinstance(schema, list):
-        return [
+        return _reorder_float_unions([
             _parse_schema(
                 s, namespace, expand, False, named_schemas
             ) for s in schema
-        ]
+        ])
 
     # string schemas; this could be either a named schema or a primitive type
     elif not isinstance(schema, dict):

--- a/tests/test_fastavro.py
+++ b/tests/test_fastavro.py
@@ -1207,6 +1207,47 @@ def test_write_union_tuple_primitive():
     assert new_records == expected_data
 
 
+def test_write_union_float_double():
+    '''
+    Test that when we can use tuple style of writing unions
+    (see function `write_union` in `_write`) with primitives
+     not only with records.
+    '''
+
+    schema = {
+        'name': 'test_name',
+        'namespace': 'test',
+        'type': 'record',
+        'fields': [
+            {
+                'name': 'val',
+                'type': ['float', 'double', 'float', 'int', 'double'],
+            }
+        ]
+    }
+
+    data = [
+        {"val": ('double', 3.1236809483509432)},
+        {"val": 3.1236809483509432},
+        {"val": 2.0},
+    ]
+
+    expected_data = [
+        {"val": 3.1236809483509432},
+        {"val": 3.1236809483509432},
+        {"val": 2.0},
+    ]
+
+    new_file = MemoryIO()
+    fastavro.writer(new_file, schema, data)
+    new_file.seek(0)
+
+    new_reader = fastavro.reader(new_file)
+    new_records = list(new_reader)
+
+    assert new_records == expected_data
+
+
 def test_doubles_set_to_zero_on_windows():
     """https://github.com/fastavro/fastavro/issues/154"""
 


### PR DESCRIPTION
We have encountered a problem with union types that contain both 'float' and 'double'. The problem occurs writing a python float into a union type `['float', 'double']`. fastavro processes each type in the union in order, finds that the float matches, and narrows the python float (64 bits) to an avro float (32 bits), resulting in a loss of precision. Reading is not an issue because widening a float to a double is lossless.

This problem only occurs when writing and only in Python because of the ambiguity arising from having a single float type. We considered several possible solutions to this problem:

1. Never narrow python floats to avro floats. This solves the problem because the 'float' type in the union will no longer match, but it leaves python with no way to write to "float" type. In general, implicit narrowing is not great, but the lack of a way to explicitely narrow floats when needed ruled out this option.
2. Just fix the schema. One could argue that such union types are simply wrong and the library should not handle this case. Unfortunately, we have several of these schemas in the wild that are not easy to change. Moreover, our system also has C and Java producers and these schemas are handled there since these languages have explicit float/double types so there is no ambiguity.
3. Handle the issue in the `write_union` function. This works but was rejected for performance reasons. We parse a schem once and use it to write many times, so handling the issue when parsing the schema is beneficial.

I do not love modifying the schema in flight, so I'm open to any suggestions of an alternate solution. It's understandable for the fastavro project to take option 2 and not solve the problem at all but this solution works so I figured I might as well share just in case.