### PR TITLE
Add a new logical type for fixed size signed and unsigned integers

### DIFF
--- a/fastavro/_logical_writers.pyx
+++ b/fastavro/_logical_writers.pyx
@@ -275,7 +275,7 @@ cdef prepare_fixed_sized_uint(data, schema):
 
     if size == 1:
         d1 = <unsigned char> data
-        output[i] = <char> d1
+        output[0] = <char> d1
     elif size == 2:
         d2 = <unsigned short> data
         for i in range(0, size):

--- a/fastavro/_logical_writers.pyx
+++ b/fastavro/_logical_writers.pyx
@@ -7,10 +7,11 @@ import os
 import uuid
 
 from libc.time cimport tm, mktime
-from cpython.int cimport PyInt_AS_LONG
-from cpython.long cimport PyLong_AsLongLong, PyLong_AsUnsignedLongLong
+from cpython.int cimport PyInt_AS_LONG, PyInt_AsUnsignedLongLongMask
+from cpython.long cimport PyLong_AsLongLong, PyLong_AsUnsignedLongLong, PyLong_Check
 from cpython.tuple cimport PyTuple_GET_ITEM
 from cpython.array cimport array, clone
+from cpython.version cimport PY_MAJOR_VERSION
 
 from fastavro import const
 from ._six import long, mk_bits, int_to_be_signed_bytes
@@ -248,7 +249,26 @@ cdef prepare_fixed_sized_uint(data, schema):
     size = schema['size']
     output = clone(_int_buffer, size, False)
 
-    cdef long long d = PyLong_AsUnsignedLongLong(<object>data)
+    cdef long long d = PyLong_AsUnsignedLongLong(<object> data)
+
+    for i in range(0, size):
+        output[i] = <char> d
+        d >>= 8
+
+    return output.data.as_chars[:size]
+
+
+cdef prepare_fixed_sized_uint2(data, schema):
+    size = schema['size']
+    output = clone(_int_buffer, size, False)
+
+    cdef long long d
+    cdef object objdata = <object>data
+
+    if PyLong_Check(objdata):
+        d = PyLong_AsUnsignedLongLong(objdata)
+    else:
+        d = PyInt_AsUnsignedLongLongMask(objdata)
 
     for i in range(0, size):
         output[i] = <char> d
@@ -267,5 +287,10 @@ LOGICAL_WRITERS = {
     'int-time-millis': prepare_time_millis,
     'long-time-micros': prepare_time_micros,
     'fixed-sized-int': prepare_fixed_sized_int,
-    'fixed-sized-uint': prepare_fixed_sized_uint,
 }
+
+
+if PY_MAJOR_VERSION > 3:
+    LOGICAL_WRITERS['fixed-sized-uint'] = prepare_fixed_sized_uint
+else:
+    LOGICAL_WRITERS['fixed-sized-uint'] = prepare_fixed_sized_uint2

--- a/fastavro/_logical_writers.pyx
+++ b/fastavro/_logical_writers.pyx
@@ -8,6 +8,7 @@ import uuid
 
 from libc.time cimport tm, mktime
 from cpython.int cimport PyInt_AS_LONG
+from cpython.long cimport PyLong_AsLongLong, PyLong_AsUnsignedLongLong
 from cpython.tuple cimport PyTuple_GET_ITEM
 from cpython.array cimport array, clone
 
@@ -226,71 +227,32 @@ cpdef prepare_time_micros(object data, schema):
     else:
         return data
 
+
 cdef _int_buffer = array('b')
 
-cdef prepare_fixed_sized_int(data, schema):
-    cdef:
-        int i
-        int size
-        array output
-        short d2
-        int d4
-        long64 d8
 
-    size = <int> schema['size']
+cdef prepare_fixed_sized_int(data, schema):
+    size = schema['size']
     output = clone(_int_buffer, size, False)
 
-    if size == 1:
-        output[0] = <char> data
-    elif size == 2:
-        d2 = <short> data
-        for i in range(0, size):
-            output[i] = <char> d2
-            d2 >>= 8
-    elif size == 4:
-        d4 = <int> data
-        for i in range(0, size):
-            output[i] = <char> d4
-            d4 >>= 8
-    elif size == 8:
-        d8 = <long64> data
-        for i in range(0, size):
-            output[i] = <char> d8
-            d8 >>= 8
+    cdef long long d = PyLong_AsLongLong(<object>data)
+
+    for i in range(0, size):
+        output[i] = <char> d
+        d >>= 8
 
     return output.data.as_chars[:size]
 
 
 cdef prepare_fixed_sized_uint(data, schema):
-    cdef:
-        int i
-        int size
-        array output
-        unsigned short d2
-        unsigned int d4
-        unsigned long long d8
-
-    size = <int> schema['size']
+    size = schema['size']
     output = clone(_int_buffer, size, False)
 
-    if size == 1:
-        d1 = <unsigned char> data
-        output[0] = <char> d1
-    elif size == 2:
-        d2 = <unsigned short> data
-        for i in range(0, size):
-            output[i] = <char> d2
-            d2 >>= 8
-    elif size == 4:
-        d4 = <unsigned int> data
-        for i in range(0, size):
-            output[i] = <char> d4
-            d4 >>= 8
-    elif size == 8:
-        d8 = <unsigned long long> data
-        for i in range(0, size):
-            output[i] = <char> d8
-            d8 >>= 8
+    cdef long long d = PyLong_AsUnsignedLongLong(<object>data)
+
+    for i in range(0, size):
+        output[i] = <char> d
+        d >>= 8
 
     return output.data.as_chars[:size]
 

--- a/fastavro/_logical_writers_py.py
+++ b/fastavro/_logical_writers_py.py
@@ -207,7 +207,7 @@ def prepare_fixed_sized_int(data, schema):
 
 def prepare_fixed_sized_uint(data, schema):
     size = schema['size']
-    fmt = _fixed_int_formats[size]
+    fmt = _fixed_uint_formats[size]
     return pack(fmt, data)
 
 

--- a/fastavro/_logical_writers_py.py
+++ b/fastavro/_logical_writers_py.py
@@ -198,6 +198,7 @@ _fixed_uint_formats = {
     8: 'Q',
 }
 
+
 def prepare_fixed_sized_int(data, schema):
     size = schema['size']
     fmt = _fixed_int_formats[size]

--- a/fastavro/_logical_writers_py.py
+++ b/fastavro/_logical_writers_py.py
@@ -1,10 +1,12 @@
 # cython: auto_cpdef=True
 
+from struct import pack
 import datetime
 import decimal
 import os
 import time
 import uuid
+
 from .const import (
     MCS_PER_HOUR, MCS_PER_MINUTE, MCS_PER_SECOND, MLS_PER_HOUR, MLS_PER_MINUTE,
     MLS_PER_SECOND, DAYS_SHIFT
@@ -183,6 +185,31 @@ def prepare_time_micros(data, schema):
         return data
 
 
+_fixed_int_formats = {
+    1: 'b',
+    2: 'h',
+    4: 'i',
+    8: 'q',
+}
+_fixed_uint_formats = {
+    1: 'B',
+    2: 'H',
+    4: 'I',
+    8: 'Q',
+}
+
+def prepare_fixed_sized_int(data, schema):
+    size = schema['size']
+    fmt = _fixed_int_formats[size]
+    return pack(fmt, data)
+
+
+def prepare_fixed_sized_uint(data, schema):
+    size = schema['size']
+    fmt = _fixed_int_formats[size]
+    return pack(fmt, data)
+
+
 LOGICAL_WRITERS = {
     'long-timestamp-millis': prepare_timestamp_millis,
     'long-timestamp-micros': prepare_timestamp_micros,
@@ -192,5 +219,6 @@ LOGICAL_WRITERS = {
     'string-uuid': prepare_uuid,
     'int-time-millis': prepare_time_millis,
     'long-time-micros': prepare_time_micros,
-
+    'fixed-sized-int': prepare_fixed_sized_int,
+    'fixed-sized-uint': prepare_fixed_sized_uint,
 }

--- a/fastavro/_read.pyx
+++ b/fastavro/_read.pyx
@@ -18,6 +18,7 @@ from struct import unpack
 import json
 
 from cpython.long cimport PyLong_FromLongLong, PyLong_FromUnsignedLongLong
+from cpython.version cimport PY_MAJOR_VERSION
 
 from ._six import (
     btou, utob, iteritems, is_str, long, be_signed_bytes_to_int
@@ -505,12 +506,33 @@ cpdef read_fixed_sized_int(data, writer_schema=None, reader_schema=None):
     return PyLong_FromLongLong(-(d & mask) + (d & ~mask))
 
 
+cpdef read_fixed_sized_int2(data, writer_schema=None, reader_schema=None):
+    size = writer_schema['size']
+    cdef unsigned long long mask = 2 ** (size * 8 - 1)
+    cdef unsigned long long d = 0
+
+    for i in range(size - 1, -1, -1):
+        d |= ord(data[i]) << (i * 8)
+
+    return PyLong_FromLongLong(-(d & mask) + (d & ~mask))
+
+
 cpdef read_fixed_sized_uint(data, writer_schema=None, reader_schema=None):
     size = writer_schema['size']
     cdef unsigned long long d = 0
 
     for i in range(size - 1, -1, -1):
         d |= data[i] << (i * 8)
+
+    return PyLong_FromUnsignedLongLong(d)
+
+
+cpdef read_fixed_sized_uint2(data, writer_schema=None, reader_schema=None):
+    size = writer_schema['size']
+    cdef unsigned long long d = 0
+
+    for i in range(size - 1, -1, -1):
+        d |= ord(data[i]) << (i * 8)
 
     return PyLong_FromUnsignedLongLong(d)
 
@@ -524,9 +546,14 @@ LOGICAL_READERS = {
     'string-uuid': read_uuid,
     'int-time-millis': read_time_millis,
     'long-time-micros': read_time_micros,
-    'fixed-sized-int': read_fixed_sized_int,
-    'fixed-sized-uint': read_fixed_sized_uint,
 }
+
+if PY_MAJOR_VERSION >= 3:
+    LOGICAL_READERS['fixed-sized-int'] = read_fixed_sized_int
+    LOGICAL_READERS['fixed-sized-uint'] = read_fixed_sized_uint
+else:
+    LOGICAL_READERS['fixed-sized-int'] = read_fixed_sized_int2
+    LOGICAL_READERS['fixed-sized-uint'] = read_fixed_sized_uint2
 
 
 cpdef maybe_promote(data, writer_type, reader_type):

--- a/fastavro/_read.pyx
+++ b/fastavro/_read.pyx
@@ -496,7 +496,7 @@ cdef read_record(fo, writer_schema, reader_schema=None, return_record_name=False
 
 cpdef read_fixed_sized_int(data, writer_schema=None, reader_schema=None):
     size = writer_schema['size']
-    mask = 2 ** (size * 8 - 1)
+    cdef unsigned long long mask = 2 ** (size * 8 - 1)
     cdef unsigned long long d = 0
 
     for i in range(size - 1, -1, -1):

--- a/fastavro/_read.pyx
+++ b/fastavro/_read.pyx
@@ -17,7 +17,7 @@ from struct import unpack
 
 import json
 
-from cpython.long import PyLong_FromLongLong, PyLong_FromUnsignedLongLong
+from cpython.long cimport PyLong_FromLongLong, PyLong_FromUnsignedLongLong
 
 from ._six import (
     btou, utob, iteritems, is_str, long, be_signed_bytes_to_int
@@ -496,12 +496,13 @@ cdef read_record(fo, writer_schema, reader_schema=None, return_record_name=False
 
 cpdef read_fixed_sized_int(data, writer_schema=None, reader_schema=None):
     size = writer_schema['size']
-    cdef long long d = 0
+    mask = 2 ** (size * 8 - 1)
+    cdef unsigned long long d = 0
 
     for i in range(size - 1, -1, -1):
         d |= data[i] << (i * 8)
 
-    return PyLong_FromLongLong(d)
+    return PyLong_FromLongLong(-(d & mask) + (d & ~mask))
 
 
 cpdef read_fixed_sized_uint(data, writer_schema=None, reader_schema=None):

--- a/fastavro/_read.pyx
+++ b/fastavro/_read.pyx
@@ -17,6 +17,8 @@ from struct import unpack
 
 import json
 
+from cpython.long import PyLong_FromLongLong, PyLong_FromUnsignedLongLong
+
 from ._six import (
     btou, utob, iteritems, is_str, long, be_signed_bytes_to_int
 )
@@ -492,32 +494,24 @@ cdef read_record(fo, writer_schema, reader_schema=None, return_record_name=False
     return record
 
 
-_fixed_int_formats = {
-    1: 'b',
-    2: 'h',
-    4: 'i',
-    8: 'q',
-}
-
-
-_fixed_uint_formats = {
-    1: 'B',
-    2: 'H',
-    4: 'I',
-    8: 'Q',
-}
-
-
-def read_fixed_sized_int(data, writer_schema=None, reader_schema=None):
+cpdef read_fixed_sized_int(data, writer_schema=None, reader_schema=None):
     size = writer_schema['size']
-    fmt = _fixed_int_formats[size]
-    return unpack(fmt, data)[0]
+    cdef long long d = 0
+
+    for i in range(size - 1, -1, -1):
+        d |= data[i] << (i * 8)
+
+    return PyLong_FromLongLong(d)
 
 
-def read_fixed_sized_uint(data, writer_schema=None, reader_schema=None):
+cpdef read_fixed_sized_uint(data, writer_schema=None, reader_schema=None):
     size = writer_schema['size']
-    fmt = _fixed_uint_formats[size]
-    return unpack(fmt, data)[0]
+    cdef unsigned long long d = 0
+
+    for i in range(size - 1, -1, -1):
+        d |= data[i] << (i * 8)
+
+    return PyLong_FromUnsignedLongLong(d)
 
 
 LOGICAL_READERS = {

--- a/fastavro/_read.pyx
+++ b/fastavro/_read.pyx
@@ -13,6 +13,7 @@ import datetime
 from decimal import Context
 from fastavro.six import MemoryIO
 from uuid import UUID
+from struct import unpack
 
 import json
 
@@ -491,6 +492,34 @@ cdef read_record(fo, writer_schema, reader_schema=None, return_record_name=False
     return record
 
 
+_fixed_int_formats = {
+    1: 'b',
+    2: 'h',
+    4: 'i',
+    8: 'q',
+}
+
+
+_fixed_uint_formats = {
+    1: 'B',
+    2: 'H',
+    4: 'I',
+    8: 'Q',
+}
+
+
+def read_fixed_sized_int(data, writer_schema=None, reader_schema=None):
+    size = writer_schema['size']
+    fmt = _fixed_int_formats[size]
+    return unpack(fmt, data)[0]
+
+
+def read_fixed_sized_uint(data, writer_schema=None, reader_schema=None):
+    size = writer_schema['size']
+    fmt = _fixed_uint_formats[size]
+    return unpack(fmt, data)[0]
+
+
 LOGICAL_READERS = {
     'long-timestamp-millis': read_timestamp_millis,
     'long-timestamp-micros': read_timestamp_micros,
@@ -500,6 +529,8 @@ LOGICAL_READERS = {
     'string-uuid': read_uuid,
     'int-time-millis': read_time_millis,
     'long-time-micros': read_time_micros,
+    'fixed-sized-int': read_fixed_sized_int,
+    'fixed-sized-uint': read_fixed_sized_uint,
 }
 
 

--- a/fastavro/_read_py.py
+++ b/fastavro/_read_py.py
@@ -8,6 +8,7 @@
 
 from fastavro.six import MemoryIO
 from struct import error as StructError
+from struct import unpack
 import bz2
 import zlib
 import datetime
@@ -366,6 +367,30 @@ def read_record(decoder, writer_schema, reader_schema=None,
 
     return record
 
+_fixed_int_formats = {
+    1: 'b',
+    2: 'h',
+    4: 'i',
+    8: 'q',
+}
+_fixed_uint_formats = {
+    1: 'B',
+    2: 'H',
+    4: 'I',
+    8: 'Q',
+}
+
+def read_fixed_sized_int(data, writer_schema=None, reader_schema=None):
+    size = writer_schema['size']
+    fmt = _fixed_int_formats[size]
+    return unpack(fmt, data)[0]
+
+
+def read_fixed_sized_uint(data, writer_schema=None, reader_schema=None):
+    size = writer_schema['size']
+    fmt = _fixed_uint_formats[size]
+    return unpack(fmt, data)[0]
+
 
 LOGICAL_READERS = {
     'long-timestamp-millis': read_timestamp_millis,
@@ -376,6 +401,8 @@ LOGICAL_READERS = {
     'string-uuid': read_uuid,
     'int-time-millis': read_time_millis,
     'long-time-micros': read_time_micros,
+    'fixed-sized-int': read_fixed_sized_int,
+    'fixed-sized-uint': read_fixed_sized_uint,
 }
 
 READERS = {

--- a/fastavro/_read_py.py
+++ b/fastavro/_read_py.py
@@ -367,18 +367,22 @@ def read_record(decoder, writer_schema, reader_schema=None,
 
     return record
 
+
 _fixed_int_formats = {
     1: 'b',
     2: 'h',
     4: 'i',
     8: 'q',
 }
+
+
 _fixed_uint_formats = {
     1: 'B',
     2: 'H',
     4: 'I',
     8: 'Q',
 }
+
 
 def read_fixed_sized_int(data, writer_schema=None, reader_schema=None):
     size = writer_schema['size']

--- a/fastavro/_write_py.py
+++ b/fastavro/_write_py.py
@@ -80,6 +80,11 @@ def write_fixed(encoder, datum, schema=None):
     schema."""
     encoder.write_fixed(datum)
 
+def write_fixed_ints(encode, datum, ctype, schema=None):
+    """Fixed size integers of type int8_t
+    """
+    encoder.write_fixed(bytes(ctype(datum)))
+
 
 def write_enum(encoder, datum, schema):
     """An enum is encoded by a int, representing the zero-based position of

--- a/fastavro/_write_py.py
+++ b/fastavro/_write_py.py
@@ -80,11 +80,6 @@ def write_fixed(encoder, datum, schema=None):
     schema."""
     encoder.write_fixed(datum)
 
-def write_fixed_ints(encode, datum, ctype, schema=None):
-    """Fixed size integers of type int8_t
-    """
-    encoder.write_fixed(bytes(ctype(datum)))
-
 
 def write_enum(encoder, datum, schema):
     """An enum is encoded by a int, representing the zero-based position of

--- a/tests/test_logical_types.py
+++ b/tests/test_logical_types.py
@@ -455,3 +455,78 @@ def test_pandas_datetime():
         )
     }
     assert serialize(schema, data1)
+
+
+
+# test fixed decimal
+schemas_fixed_sized_int = {
+    "int8": { "name": "int8_t", "type": "fixed", "size": 1, "logicalType": "sized-int" },
+    "int16": { "name": "int16_t", "type": "fixed", "size": 2, "logicalType": "sized-int" },
+    "int32": { "name": "int32_t", "type": "fixed", "size": 4, "logicalType": "sized-int" },
+    "int64": { "name": "int64_t", "type": "fixed", "size": 8, "logicalType": "sized-int" },
+    "uint8": { "name": "uint8_t", "type": "fixed", "size": 1, "logicalType": "sized-uint" },
+    "uint16": { "name": "uint16_t", "type": "fixed", "size": 2, "logicalType": "sized-uint" },
+    "uint32": { "name": "uint32_t", "type": "fixed", "size": 4, "logicalType": "sized-uint" },
+    "uint64": { "name": "uint64_t", "type": "fixed", "size": 8, "logicalType": "sized-uint" },
+}
+
+def test_fixed_size_int8():
+    data1 = -128
+    schema = schemas_fixed_sized_int["int8"]
+    binary = serialize(schema, data1)
+    data2 = deserialize(schema, binary)
+    assert (data1 == data2)
+    assert (len(binary) == schema['size'])
+
+    data1 = 127
+    schema = schemas_fixed_sized_int["int8"]
+    binary = serialize(schema, data1)
+    data2 = deserialize(schema, binary)
+    assert (data1 == data2)
+    assert (len(binary) == schema['size'])
+
+def test_fixed_size_int16():
+    data1 = -32768
+    schema = schemas_fixed_sized_int["int16"]
+    binary = serialize(schema, data1)
+    data2 = deserialize(schema, binary)
+    assert (data1 == data2)
+    assert (len(binary) == schema['size'])
+
+    data1 = 32767
+    schema = schemas_fixed_sized_int["int16"]
+    binary = serialize(schema, data1)
+    data2 = deserialize(schema, binary)
+    assert (data1 == data2)
+    assert (len(binary) == schema['size'])
+
+def test_fixed_size_int32():
+    data1 = -2147483648
+    schema = schemas_fixed_sized_int["int32"]
+    binary = serialize(schema, data1)
+    data2 = deserialize(schema, binary)
+    assert (data1 == data2)
+    assert (len(binary) == schema['size'])
+
+    data1 = 2147483647
+    schema = schemas_fixed_sized_int["int32"]
+    binary = serialize(schema, data1)
+    data2 = deserialize(schema, binary)
+    assert (data1 == data2)
+    assert (len(binary) == schema['size'])
+
+def test_fixed_size_int8():
+    data1 = -2305843009213693952
+    schema = schemas_fixed_sized_int["int64"]
+    binary = serialize(schema, data1)
+    data2 = deserialize(schema, binary)
+    assert (data1 == data2)
+    assert (len(binary) == schema['size'])
+
+    data1 = 2305843009213693951
+    schema = schemas_fixed_sized_int["int64"]
+    binary = serialize(schema, data1)
+    data2 = deserialize(schema, binary)
+    assert (data1 == data2)
+    assert (len(binary) == schema['size'])
+

--- a/tests/test_logical_types.py
+++ b/tests/test_logical_types.py
@@ -457,18 +457,34 @@ def test_pandas_datetime():
     assert serialize(schema, data1)
 
 
-
-# test fixed decimal
+# test fixed sized integers
 schemas_fixed_sized_int = {
-    "int8": { "name": "int8_t", "type": "fixed", "size": 1, "logicalType": "sized-int" },
-    "int16": { "name": "int16_t", "type": "fixed", "size": 2, "logicalType": "sized-int" },
-    "int32": { "name": "int32_t", "type": "fixed", "size": 4, "logicalType": "sized-int" },
-    "int64": { "name": "int64_t", "type": "fixed", "size": 8, "logicalType": "sized-int" },
-    "uint8": { "name": "uint8_t", "type": "fixed", "size": 1, "logicalType": "sized-uint" },
-    "uint16": { "name": "uint16_t", "type": "fixed", "size": 2, "logicalType": "sized-uint" },
-    "uint32": { "name": "uint32_t", "type": "fixed", "size": 4, "logicalType": "sized-uint" },
-    "uint64": { "name": "uint64_t", "type": "fixed", "size": 8, "logicalType": "sized-uint" },
-}
+    "int8": {
+        "name": "int8_t", "type": "fixed",
+        "size": 1, "logicalType": "sized-int",
+    }, "int16": {
+        "name": "int16_t", "type": "fixed",
+        "size": 2, "logicalType": "sized-int",
+    }, "int32": {
+        "name": "int32_t", "type": "fixed",
+        "size": 4, "logicalType": "sized-int",
+    }, "int64": {
+        "name": "int64_t", "type": "fixed",
+        "size": 8, "logicalType": "sized-int",
+    }, "uint8": {
+        "name": "uint8_t", "type": "fixed",
+        "size": 1, "logicalType": "sized-uint",
+    }, "uint16": {
+        "name": "uint16_t", "type": "fixed",
+        "size": 2, "logicalType": "sized-uint",
+    }, "uint32": {
+        "name": "uint32_t", "type": "fixed",
+        "size": 4, "logicalType": "sized-uint",
+    }, "uint64": {
+        "name": "uint64_t", "type": "fixed",
+        "size": 8, "logicalType": "sized-uint",
+    }, }
+
 
 def test_fixed_size_int8():
     data1 = -128
@@ -485,6 +501,7 @@ def test_fixed_size_int8():
     assert (data1 == data2)
     assert (len(binary) == schema['size'])
 
+
 def test_fixed_size_int16():
     data1 = -32768
     schema = schemas_fixed_sized_int["int16"]
@@ -499,6 +516,7 @@ def test_fixed_size_int16():
     data2 = deserialize(schema, binary)
     assert (data1 == data2)
     assert (len(binary) == schema['size'])
+
 
 def test_fixed_size_int32():
     data1 = -2147483648
@@ -515,7 +533,8 @@ def test_fixed_size_int32():
     assert (data1 == data2)
     assert (len(binary) == schema['size'])
 
-def test_fixed_size_int8():
+
+def test_fixed_size_int64():
     data1 = -2305843009213693952
     schema = schemas_fixed_sized_int["int64"]
     binary = serialize(schema, data1)
@@ -530,3 +549,66 @@ def test_fixed_size_int8():
     assert (data1 == data2)
     assert (len(binary) == schema['size'])
 
+
+def test_fixed_size_uint8():
+    data1 = 255
+    schema = schemas_fixed_sized_int["uint8"]
+    binary = serialize(schema, data1)
+    data2 = deserialize(schema, binary)
+    assert (data1 == data2)
+    assert (len(binary) == schema['size'])
+
+    data1 = 0
+    schema = schemas_fixed_sized_int["uint8"]
+    binary = serialize(schema, data1)
+    data2 = deserialize(schema, binary)
+    assert (data1 == data2)
+    assert (len(binary) == schema['size'])
+
+
+def test_fixed_size_uint16():
+    data1 = 65535
+    schema = schemas_fixed_sized_int["uint16"]
+    binary = serialize(schema, data1)
+    data2 = deserialize(schema, binary)
+    assert (data1 == data2)
+    assert (len(binary) == schema['size'])
+
+    data1 = 0
+    schema = schemas_fixed_sized_int["uint16"]
+    binary = serialize(schema, data1)
+    data2 = deserialize(schema, binary)
+    assert (data1 == data2)
+    assert (len(binary) == schema['size'])
+
+
+def test_fixed_size_uint32():
+    data1 = 4294967295
+    schema = schemas_fixed_sized_int["uint32"]
+    binary = serialize(schema, data1)
+    data2 = deserialize(schema, binary)
+    assert (data1 == data2)
+    assert (len(binary) == schema['size'])
+
+    data1 = 0
+    schema = schemas_fixed_sized_int["uint32"]
+    binary = serialize(schema, data1)
+    data2 = deserialize(schema, binary)
+    assert (data1 == data2)
+    assert (len(binary) == schema['size'])
+
+
+def test_fixed_size_uint64():
+    data1 = 18446744073709551615
+    schema = schemas_fixed_sized_int["uint64"]
+    binary = serialize(schema, data1)
+    data2 = deserialize(schema, binary)
+    assert (data1 == data2)
+    assert (len(binary) == schema['size'])
+
+    data1 = 0
+    schema = schemas_fixed_sized_int["uint64"]
+    binary = serialize(schema, data1)
+    data2 = deserialize(schema, binary)
+    assert (data1 == data2)
+    assert (len(binary) == schema['size'])


### PR DESCRIPTION
Adds two new logical types: `sized-int` and `sized-uint`. These types allow for a schema like 
`{"type": "fixed", "size": 1, "logicalType": "sized_uint"}` which is equivalent to the C level `uint8_t` type. Notice that the logical type only indicates signed versus unsigned, since the size is already handled by the underlying fixed type.

This PR contains both a pure python implementation using the `struct` package and a hand-written cython implementation. The latter implementation is what we rely on in practice so care was taken to make it as efficient as practical. The special casing this required for Python versions is unfortunate and I would love to find an equally efficient solution that did not require it.

You may recall a similar PR a long time ago for the same feature, but based on the "name" rather than "logicalType". Our goal is the same, but the logical types feature made this addition much cleaner.

Happy to squash commits if that is preferred.