### PR TITLE
Redo import logic for optional *_write_block functions

### DIFF
--- a/fastavro/_write.pyx
+++ b/fastavro/_write.pyx
@@ -452,7 +452,7 @@ cpdef lz4_write_block(object fo, bytes block_bytes, compression_level):
 
 
 if BLOCK_WRITERS.get("lz4") is None:
-    BLOCK_WRITERS["lz"] = lz4_write_block
+    BLOCK_WRITERS["lz4"] = lz4_write_block
 
 
 try:

--- a/fastavro/_write.pyx
+++ b/fastavro/_write.pyx
@@ -398,8 +398,6 @@ try:
     import snappy
 except ImportError:
     BLOCK_WRITERS['snappy'] = _missing_dependency("snappy", "python-snappy")
-else:
-    BLOCK_WRITERS['snappy'] = snappy_write_block
 
 
 cpdef snappy_write_block(object fo, bytes block_bytes, compression_level):
@@ -415,12 +413,14 @@ cpdef snappy_write_block(object fo, bytes block_bytes, compression_level):
     fo.write(tmp)
 
 
+if BLOCK_WRITERS.get('snappy') is None:
+    BLOCK_WRITERS['snappy'] = snappy_write_block
+
+
 try:
     import zstandard as zstd
 except ImportError:
     BLOCK_WRITERS["zstandard"] = _missing_dependency("zstandard", "zstandard")
-else:
-    BLOCK_WRITERS["zstandard"] = zstandard_write_block
 
 
 cpdef zstandard_write_block(object fo, bytes block_bytes, compression_level):
@@ -432,12 +432,14 @@ cpdef zstandard_write_block(object fo, bytes block_bytes, compression_level):
     fo.write(data)
 
 
+if BLOCK_WRITERS.get("zstandard") is None:
+    BLOCK_WRITERS["zstandard"] = zstandard_write_block
+
+
 try:
     import lz4.block
 except ImportError:
     BLOCK_WRITERS["lz4"] = _missing_dependency("lz4", "lz4")
-else:
-    BLOCK_WRITERS["lz4"] = lz4_write_block
 
 
 cpdef lz4_write_block(object fo, bytes block_bytes, compression_level):
@@ -449,6 +451,10 @@ cpdef lz4_write_block(object fo, bytes block_bytes, compression_level):
     fo.write(data)
 
 
+if BLOCK_WRITERS.get("lz4") is None:
+    BLOCK_WRITERS["lz"] = lz4_write_block
+
+
 try:
     import lzma
 except ImportError:
@@ -456,10 +462,6 @@ except ImportError:
         from backports import lzma
     except ImportError:
         BLOCK_WRITERS["xz"] = _missing_dependency("xz", "backports.lzma")
-    else:
-        BLOCK_WRITERS["xz"] = xz_write_block
-else:
-    BLOCK_WRITERS["xz"] = xz_write_block
 
 
 cpdef xz_write_block(object fo, bytes block_bytes, compression_level):
@@ -469,6 +471,10 @@ cpdef xz_write_block(object fo, bytes block_bytes, compression_level):
     write_long(tmp, len(data))
     fo.write(tmp)
     fo.write(data)
+
+
+if BLOCK_WRITERS.get("xz") is None:
+    BLOCK_WRITERS["xz"] = xz_write_block
 
 
 cdef class MemoryIO(object):


### PR DESCRIPTION
The current logic appears to have an issue with cython build under python3.4, or at least python3.4 on centos 7, which is the only place I tested it.

To reproduce the current problem, build a wheel package with python3.4:

```sh
FASTAVRO_USE_CYTHON=1 python3.4 setup.py bdist_wheel
```

Then install that package. Not sure if the force is needed, I include it to be sure.

```sh
python3.4 -m pip install --upgrade --force-reinstall dist/fastavro-0.23.3-cp34-cp34m-linux_x86_64.whl
```

From a *directory other than the repository root*, try to import the fastavro package.

```sh
python3.4 -c 'import fastavro'
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/usr/lib64/python3.4/site-packages/fastavro/__init__.py", line 48, in <module>
    import fastavro.write
  File "/usr/lib64/python3.4/site-packages/fastavro/write.py", line 2, in <module>
    from . import _write
  File "fastavro/_write.pyx", line 462, in init fastavro._write
NameError: name 'xz_write_block' is not defined
```

If you try to import from the repository root, python will import the fastavro directory instead of the installed package and you won't see the problem.

This problem does not occur on python3.6 or python2.7 (did not test python3.5) but the new import logic works on 2.7, 3.4, 3.5, and 3.6. I did not test 3.7 but I would expect it to work.

I don't know why the problem occurs exactly. If you build using `make all` with the latest version of the `cython` CLI and don't set `FASTAVRO_USE_CYTHON=1`, python3.4 does work. That makes me suspect a Cython version issue but I did not go any further down that path.