### PR TITLE
Convert iterables to list in cython array writing

### DIFF
--- a/fastavro/_write.pyx
+++ b/fastavro/_write.pyx
@@ -326,6 +326,8 @@ cpdef write_data(bytearray fo, datum, schema):
     elif record_type == 'enum':
         return write_enum(fo, datum, schema)
     elif record_type == 'array':
+        if not isinstance(datum, list):
+            datum = list(datum)
         return write_array(fo, datum, schema)
     elif record_type == 'map':
         return write_map(fo, datum, schema)

--- a/tests/test_complex.py
+++ b/tests/test_complex.py
@@ -122,3 +122,8 @@ def test_complex_schema_nulls():
         {'multi_union_time': None, 'array_bytes_decimal': None,
          'array_fixed_decimal': None, 'union_uuid': None})
     assert (data1_compare == data2)
+
+def test_array_from_tuple():
+    data_list = serialize({"type": "array", "items": "int"}, [1,2,3])
+    data_tuple = serialize({"type": "array", "items": "int"}, (1,2,3))
+    assert data_list == data_tuple

--- a/tests/test_complex.py
+++ b/tests/test_complex.py
@@ -123,7 +123,8 @@ def test_complex_schema_nulls():
          'array_fixed_decimal': None, 'union_uuid': None})
     assert (data1_compare == data2)
 
+
 def test_array_from_tuple():
-    data_list = serialize({"type": "array", "items": "int"}, [1,2,3])
-    data_tuple = serialize({"type": "array", "items": "int"}, (1,2,3))
+    data_list = serialize({"type": "array", "items": "int"}, [1, 2, 3])
+    data_tuple = serialize({"type": "array", "items": "int"}, (1, 2, 3))
     assert data_list == data_tuple


### PR DESCRIPTION
In particular, I was trying to write tuples as arrays (the closest avro type).

Writing tuples (or any iterable) as an array already works in the pure python implementation, this makes the cython behavior in line with the python behavior.

P.S. I am implementing [Avro-RPC](https://gitlab.com/yaq/yaqd-core-python/-/tree/avro/yaqd_core/avrorpc) (and protocol reading #424 on top of fastavro). Currently still in early stages, not 100% standard compliant. I also use some 3.7+ features in my current implementation, but would be willing to clean it up/make it work on fastavro supported pythons once I have the finish the implementation.