### PR TITLE
show fieldname on errors of mismatched types and values

### DIFF
--- a/fastavro/_six.pyx
+++ b/fastavro/_six.pyx
@@ -71,6 +71,9 @@ if sys.version_info >= (3, 0):
     def py3_be_signed_bytes_to_int(data):
         return int.from_bytes(data, byteorder='big', signed=True)
 
+    def py3_reraise(Err, msg):
+        raise Err(msg).with_traceback(sys.exc_info()[2])
+
 
 else:  # Python 2x
     from cStringIO import StringIO as MemoryIO  # noqa
@@ -159,6 +162,11 @@ else:  # Python 2x
             return output
         return output - (2 ** bitsize)
 
+    def py2_reraise(Err, msg):
+        traceback = sys.exc_info()[2]
+        _locals = {'Err': Err, 'msg': msg, 'traceback': traceback}
+        exec('raise Err, msg, traceback', _locals)
+
 # We do it this way and not just redifine function since Cython do not like it
 if sys.version_info >= (3, 0):
     btou = py3_btou
@@ -175,6 +183,7 @@ if sys.version_info >= (3, 0):
     appendable = py3_appendable
     int_to_be_signed_bytes = py3_int_to_be_signed_bytes
     be_signed_bytes_to_int = py3_be_signed_bytes_to_int
+    reraise = py3_reraise
 else:
     btou = py2_btou
     utob = py2_utob
@@ -190,3 +199,4 @@ else:
     appendable = py2_appendable
     int_to_be_signed_bytes = py2_int_to_be_signed_bytes
     be_signed_bytes_to_int = py2_be_signed_bytes_to_int
+    reraise = py2_reraise

--- a/fastavro/_write.pyx
+++ b/fastavro/_write.pyx
@@ -15,7 +15,7 @@ import zlib
 from fastavro import const
 from ._logical_writers import LOGICAL_WRITERS
 from ._validation import _validate
-from ._six import utob, long, iteritems, appendable
+from ._six import utob, long, iteritems, appendable, reraise
 from ._read import HEADER_SCHEMA, SYNC_SIZE, MAGIC, reader
 from ._schema import extract_record_type, extract_logical_type, parse_schema
 
@@ -149,7 +149,7 @@ cdef inline write_enum(bytearray fo, datum, schema, dict named_schemas):
     write_int(fo, index)
 
 
-cdef write_array(bytearray fo, list datum, schema, dict named_schemas):
+cdef write_array(bytearray fo, list datum, schema, dict named_schemas, fname):
     """Arrays are encoded as a series of blocks.
 
     Each block consists of a long count value, followed by that many array
@@ -164,11 +164,11 @@ cdef write_array(bytearray fo, list datum, schema, dict named_schemas):
         write_long(fo, len(datum))
         dtype = schema['items']
         for item in datum:
-            write_data(fo, item, dtype, named_schemas)
+            write_data(fo, item, dtype, named_schemas, fname)
     write_long(fo, 0)
 
 
-cdef write_map(bytearray fo, object datum, dict schema, dict named_schemas):
+cdef write_map(bytearray fo, object datum, dict schema, dict named_schemas, fname):
     """Maps are encoded as a series of blocks.
 
     Each block consists of a long count value, followed by that many key/value
@@ -189,7 +189,7 @@ cdef write_map(bytearray fo, object datum, dict schema, dict named_schemas):
             vtype = schema['values']
             for key, val in iteritems(datum):
                 write_utf8(fo, key)
-                write_data(fo, val, vtype, named_schemas)
+                write_data(fo, val, vtype, named_schemas, fname)
         write_long(fo, 0)
     else:
         # Faster, special-purpose code where datum is a Python dict.
@@ -198,11 +198,11 @@ cdef write_map(bytearray fo, object datum, dict schema, dict named_schemas):
             vtype = schema['values']
             for key, val in iteritems(d_datum):
                 write_utf8(fo, key)
-                write_data(fo, val, vtype, named_schemas)
+                write_data(fo, val, vtype, named_schemas, fname)
         write_long(fo, 0)
 
 
-cdef write_union(bytearray fo, datum, schema, dict named_schemas):
+cdef write_union(bytearray fo, datum, schema, dict named_schemas, fname):
     """A union is encoded by first writing a long value indicating the
     zero-based position within the union of the schema of its value. The value
     is then encoded per the indicated schema within the union."""
@@ -225,8 +225,9 @@ cdef write_union(bytearray fo, datum, schema, dict named_schemas):
                 break
 
         if best_match_index == -1:
-            msg = 'provided union type name %s not found in schema %s' \
-                % (name, schema)
+            ff = ' for field %s' % fname if fname is not None else ''
+            msg = 'provided union type name %s not found in schema %s%s' \
+                % (name, schema, ff)
             raise ValueError(msg)
         index = best_match_index
     else:
@@ -247,13 +248,14 @@ cdef write_union(bytearray fo, datum, schema, dict named_schemas):
                     best_match_index = index
                     break
         if best_match_index == -1:
-            msg = '%r (type %s) do not match %s' % (datum, pytype, schema)
+            fld = ' on field %s' % fname if fname is not None else ''
+            msg = '%r (type %s) do not match %s%s' % (datum, pytype, schema, fld)
             raise ValueError(msg)
         index = best_match_index
 
     # write data
     write_long(fo, index)
-    write_data(fo, datum, schema[index], named_schemas)
+    write_data(fo, datum, schema[index], named_schemas, fname)
 
 
 cdef write_record(bytearray fo, object datum, dict schema, dict named_schemas):
@@ -275,9 +277,9 @@ cdef write_record(bytearray fo, object datum, dict schema, dict named_schemas):
             if name not in datum and 'default' not in field and \
                     'null' not in field['type']:
                 raise ValueError('no value and no default for %s' % name)
-            write_data(fo, datum.get(
-                name, field.get('default')), field['type'], named_schemas
-            )
+            datum2 = datum.get(name, field.get('default'))
+            fieldtype1 = field['type']
+            write_data(fo, datum2, fieldtype1, named_schemas, name)
     else:
         # Faster, special-purpose code where datum is a Python dict.
         for field in fields:
@@ -285,12 +287,12 @@ cdef write_record(bytearray fo, object datum, dict schema, dict named_schemas):
             if name not in d_datum and 'default' not in field and \
                     'null' not in field['type']:
                 raise ValueError('no value and no default for %s' % name)
-            write_data(fo, d_datum.get(
-                name, field.get('default')), field['type'], named_schemas
-            )
+            datum2 = d_datum.get(name, field.get('default'))
+            fieldtype2 = field['type']
+            write_data(fo, datum2, fieldtype2, named_schemas, name)
 
 
-cpdef write_data(bytearray fo, datum, schema, dict named_schemas):
+cpdef write_data(bytearray fo, datum, schema, dict named_schemas, fname):
     """Write a datum of data to output stream.
 
     Paramaters
@@ -311,36 +313,43 @@ cpdef write_data(bytearray fo, datum, schema, dict named_schemas):
                 datum = prepare(datum, schema)
 
     record_type = extract_record_type(schema)
-    if record_type == 'null':
-        return write_null(fo, datum)
-    elif record_type == 'string':
-        return write_utf8(fo, datum)
-    elif record_type == 'int' or record_type == 'long':
-        return write_long(fo, datum)
-    elif record_type == 'float':
-        return write_float(fo, datum)
-    elif record_type == 'double':
-        return write_double(fo, datum)
-    elif record_type == 'boolean':
-        return write_boolean(fo, datum)
-    elif record_type == 'bytes':
-        return write_bytes(fo, datum)
-    elif record_type == 'fixed':
-        return write_fixed(fo, datum, named_schemas)
-    elif record_type == 'enum':
-        return write_enum(fo, datum, schema, named_schemas)
-    elif record_type == 'array':
-        if not isinstance(datum, list):
-            datum = list(datum)
-        return write_array(fo, datum, schema, named_schemas)
-    elif record_type == 'map':
-        return write_map(fo, datum, schema, named_schemas)
-    elif record_type == 'union' or record_type == 'error_union':
-        return write_union(fo, datum, schema, named_schemas)
-    elif record_type == 'record' or record_type == 'error':
-        return write_record(fo, datum, schema, named_schemas)
-    else:
-        return write_data(fo, datum, named_schemas[record_type], named_schemas)
+    try:
+        if record_type == 'null':
+            return write_null(fo, datum)
+        elif record_type == 'string':
+            return write_utf8(fo, datum)
+        elif record_type == 'int' or record_type == 'long':
+            return write_long(fo, datum)
+        elif record_type == 'float':
+            return write_float(fo, datum)
+        elif record_type == 'double':
+            return write_double(fo, datum)
+        elif record_type == 'boolean':
+            return write_boolean(fo, datum)
+        elif record_type == 'bytes':
+            return write_bytes(fo, datum)
+        elif record_type == 'fixed':
+            return write_fixed(fo, datum, named_schemas)
+        elif record_type == 'enum':
+            return write_enum(fo, datum, schema, named_schemas)
+        elif record_type == 'array':
+            if not isinstance(datum, list):
+                datum = list(datum)
+            return write_array(fo, datum, schema, named_schemas, fname)
+        elif record_type == 'map':
+            return write_map(fo, datum, schema, named_schemas, fname)
+        elif record_type == 'union' or record_type == 'error_union':
+            return write_union(fo, datum, schema, named_schemas, fname)
+        elif record_type == 'record' or record_type == 'error':
+            return write_record(fo, datum, schema, named_schemas)
+        else:
+            schema2 = named_schemas[record_type]
+            return write_data(fo, datum, schema2, named_schemas, fname)
+    except TypeError as ex:
+        if fname:
+            msg = "{} on field {}".format(ex, fname)
+            reraise(TypeError, msg)
+        raise
 
 
 cpdef write_header(bytearray fo, dict metadata, bytes sync_marker):
@@ -349,7 +358,7 @@ cpdef write_header(bytearray fo, dict metadata, bytes sync_marker):
         'meta': {key: utob(value) for key, value in iteritems(metadata)},
         'sync': sync_marker
     }
-    write_data(fo, header, HEADER_SCHEMA, {})
+    write_data(fo, header, HEADER_SCHEMA, {}, None)
 
 
 cpdef null_write_block(object fo, bytes block_bytes, compression_level):
@@ -602,7 +611,7 @@ cdef class Writer(object):
     def write(self, record):
         if self.validate_fn:
             self.validate_fn(record, self.schema, self._named_schemas)
-        write_data(self.io.value, record, self.schema, self._named_schemas)
+        write_data(self.io.value, record, self.schema, self._named_schemas, None)
         self.block_count += 1
         if self.io.tell() >= self.sync_interval:
             self.dump()
@@ -657,5 +666,5 @@ def schemaless_writer(fo, schema, record):
     cdef bytearray tmp = bytearray()
     named_schemas = {}
     schema = parse_schema(schema, _named_schemas=named_schemas)
-    write_data(tmp, record, schema, named_schemas)
+    write_data(tmp, record, schema, named_schemas, None)
     fo.write(tmp)

--- a/fastavro/_write.pyx
+++ b/fastavro/_write.pyx
@@ -149,7 +149,7 @@ cdef inline write_enum(bytearray fo, datum, schema, dict named_schemas):
     write_int(fo, index)
 
 
-cdef write_array(bytearray fo, list datum, schema, dict named_schemas, str fname):
+cdef write_array(bytearray fo, list datum, schema, dict named_schemas, fname):
     """Arrays are encoded as a series of blocks.
 
     Each block consists of a long count value, followed by that many array
@@ -168,7 +168,7 @@ cdef write_array(bytearray fo, list datum, schema, dict named_schemas, str fname
     write_long(fo, 0)
 
 
-cdef write_map(bytearray fo, object datum, dict schema, dict named_schemas, str fname):
+cdef write_map(bytearray fo, object datum, dict schema, dict named_schemas, fname):
     """Maps are encoded as a series of blocks.
 
     Each block consists of a long count value, followed by that many key/value
@@ -202,7 +202,7 @@ cdef write_map(bytearray fo, object datum, dict schema, dict named_schemas, str 
         write_long(fo, 0)
 
 
-cdef write_union(bytearray fo, datum, schema, dict named_schemas, str fname):
+cdef write_union(bytearray fo, datum, schema, dict named_schemas, fname):
     """A union is encoded by first writing a long value indicating the
     zero-based position within the union of the schema of its value. The value
     is then encoded per the indicated schema within the union."""
@@ -291,7 +291,7 @@ cdef write_record(bytearray fo, object datum, dict schema, dict named_schemas):
             write_data(fo, d_datum_value, field['type'], named_schemas, name)
 
 
-cpdef write_data(bytearray fo, datum, schema, dict named_schemas, str fname):
+cpdef write_data(bytearray fo, datum, schema, dict named_schemas, fname):
     """Write a datum of data to output stream.
 
     Paramaters

--- a/fastavro/six.py
+++ b/fastavro/six.py
@@ -161,8 +161,9 @@ else:  # Python 2x
         return output - (2 ** bitsize)
 
     def py2_reraise(Err, msg):
-        traceback = sys.exc_info()[2] # noqa
-        exec('raise Err, msg, traceback')
+        traceback = sys.exc_info()[2]
+        _locals = {'Err': Err, 'msg': msg, 'traceback': traceback}
+        exec('raise Err, msg, traceback', _locals)
 
 # We do it this way and not just redifine function since Cython do not like it
 if sys.version_info >= (3, 0):

--- a/fastavro/six.py
+++ b/fastavro/six.py
@@ -70,6 +70,9 @@ if sys.version_info >= (3, 0):
     def py3_be_signed_bytes_to_int(data):
         return int.from_bytes(data, byteorder='big', signed=True)
 
+    def py3_reraise(Err, msg):
+        raise Err(msg).with_traceback(sys.exc_info()[2])
+
 else:  # Python 2x
     from cStringIO import StringIO as MemoryIO  # noqa
     from cStringIO import StringIO as StringIO  # noqa
@@ -157,6 +160,10 @@ else:  # Python 2x
             return output
         return output - (2 ** bitsize)
 
+    def py2_reraise(Err, msg):
+        traceback = sys.exc_info()[2] # noqa
+        exec('raise Err, msg, traceback')
+
 # We do it this way and not just redifine function since Cython do not like it
 if sys.version_info >= (3, 0):
     btou = py3_btou
@@ -173,6 +180,7 @@ if sys.version_info >= (3, 0):
     appendable = py3_appendable
     int_to_be_signed_bytes = py3_int_to_be_signed_bytes
     be_signed_bytes_to_int = py3_be_signed_bytes_to_int
+    reraise = py3_reraise
 else:
     btou = py2_btou
     utob = py2_utob
@@ -188,3 +196,4 @@ else:
     appendable = py2_appendable
     int_to_be_signed_bytes = py2_int_to_be_signed_bytes
     be_signed_bytes_to_int = py2_be_signed_bytes_to_int
+    reraise = py2_reraise

--- a/tests/test_fastavro.py
+++ b/tests/test_fastavro.py
@@ -2108,12 +2108,13 @@ def test_record_named_type():
 
 
 def test_write_required_field_name():
-    '''
+    """https://github.com/fastavro/fastavro/issues/439
+
     Test that when a TypeError is raised the fieldname is
     included in exception message allowing to figure out
     quickly what column value mismatches the schema field type.
     Useful for Null/None values in required fields also.
-    '''
+    """
 
     schema = {
         'name': 'test_required',
@@ -2136,11 +2137,12 @@ def test_write_required_field_name():
 
 
 def test_write_mismatched_field_type():
-    '''
+    """https://github.com/fastavro/fastavro/issues/439
+
     Test that when a ValueError is raised the fieldname is
     included in exception message allowing to figure out
     quickly what column mismatches the schema field type.
-    '''
+    """
 
     schema = {
         'name': 'test_required',

--- a/tests/test_fastavro.py
+++ b/tests/test_fastavro.py
@@ -1175,7 +1175,6 @@ def test_regular_vs_ordered_dict_map_typeerror():
     # be different, indicating the exception occurred at a different line
     # number.
     assert filtered_stacks[0] != filtered_stacks[1]
-    # assert filtered_stacks[0] == filtered_stacks[1]
 
 
 def test_write_union_tuple_primitive():
@@ -2110,9 +2109,10 @@ def test_record_named_type():
 
 def test_write_required_field_name():
     '''
-    Test that when we can use tuple style of writing unions
-    (see function `write_union` in `_write`) with primitives
-     not only with records.
+    Test that when a TypeError is raised the fieldname is
+    included in exception message allowing to figure out
+    quickly what column value mismatches the schema field type.
+    Useful for Null/None values in required fields also.
     '''
 
     schema = {
@@ -2131,19 +2131,15 @@ def test_write_required_field_name():
     ]
 
     new_file = MemoryIO()
-    try:
+    with pytest.raises(TypeError, match="on field age"):
         fastavro.writer(new_file, schema, data)
-        assert False, "Should've raised TypeError"
-    except TypeError as ex:
-        exs = "%s" % ex
-        assert 'age' in exs
 
 
 def test_write_mismatched_field_type():
     '''
-    Test that when we can use tuple style of writing unions
-    (see function `write_union` in `_write`) with primitives
-     not only with records.
+    Test that when a ValueError is raised the fieldname is
+    included in exception message allowing to figure out
+    quickly what column mismatches the schema field type.
     '''
 
     schema = {
@@ -2162,9 +2158,5 @@ def test_write_mismatched_field_type():
     ]
 
     new_file = MemoryIO()
-    try:
+    with pytest.raises(ValueError, match="on field age"):
         fastavro.writer(new_file, schema, data)
-        assert False, "Should've raised ValueError"
-    except ValueError as ex:
-        exs = "%s" % ex
-        assert 'age' in exs

--- a/tests/test_fastavro.py
+++ b/tests/test_fastavro.py
@@ -1102,12 +1102,12 @@ def test_regular_vs_ordered_dict_record_typeerror():
         # 'd_datum', a variable that only gets a value if the record is an
         # actual dict.
         [
-            'write_data(fo, datum2, fieldtype2, named_schemas, name)'
+            "write_data(fo, d_datum_value, field['type'], named_schemas, name)"
         ],
         # For the OrderedDict, fails directly when accessing 'datum', the
         # variable that is used if the record is *not* an actual dict.
         [
-            'write_data(fo, datum2, fieldtype1, named_schemas, name)'
+            "write_data(fo, datum_value, field['type'], named_schemas, name)"
         ]
     ]
 


### PR DESCRIPTION
### show fieldname on errors of mismatched types and values

This PR adds field names to the exception message raised when a value mismatches the type defined in the schema.

The objective is helping to figure out what column has a wrong/corrupted value or type when a `TypeError` or a `ValueError` is raised.

This is particularly useful when writing huge datasets with thousands of rows, dozen of columns and many null/None values in the source data.

Resolves https://github.com/fastavro/fastavro/issues/439