### PR TITLE
Add array.array to array, bytearray to bytes and write_int improvement

### DIFF
--- a/benchmark/timeit_benchmark.py
+++ b/benchmark/timeit_benchmark.py
@@ -1,0 +1,349 @@
+import array
+import datetime
+import timeit
+from io import BytesIO
+
+import avro
+import avro.datafile
+import fastavro
+from pytz import utc
+
+TIMEIT_FORMAT = "{:25} {:6} records, best of {:6}: {:10.6f} ms"
+
+
+def write(schema, record, num_records, runs):
+    schema = fastavro.parse_schema(schema)
+    records = [record] * num_records
+    iostream = BytesIO()
+    writer = fastavro.writer
+    duration = timeit.repeat(
+        "iostream.seek(0);"
+        "writer(iostream, schema, records);",
+        number=1,
+        repeat=runs,
+        globals=locals())
+    print(
+        TIMEIT_FORMAT.format("write fastavro", num_records, runs,
+                             min(duration) * 1e3))
+    return iostream
+
+
+def write_avro(schema, record, num_records, runs):
+    records = [record] * num_records
+    iostream = BytesIO()
+
+    avro_writer = avro.datafile.DataFileWriter
+    schema = avro.schema.make_avsc_object(schema)
+    datum_writer = avro.io.DatumWriter(schema)
+
+    duration = timeit.repeat("""
+iostream.seek(0)
+writer = avro_writer(iostream, datum_writer, schema)
+for record in records:
+    writer.append(record);
+writer.flush()
+""",
+                             number=1,
+                             repeat=runs,
+                             globals=locals())
+    print(
+        TIMEIT_FORMAT.format("write avro", num_records, runs,
+                             min(duration) * 1e3))
+    return iostream
+
+
+def write_schemaless(schema, record, num_records, runs):
+    schema = fastavro.parse_schema(schema)
+    iostream = BytesIO()
+    schemaless_writer = fastavro.schemaless_writer
+    duration = timeit.repeat(
+        "iostream.seek(0);"
+        "schemaless_writer(iostream, schema, record);",
+        number=num_records,
+        repeat=runs,
+        globals=locals())
+    print(
+        TIMEIT_FORMAT.format("write schemaless fastavro", num_records, runs,
+                             min(duration) * 1e3))
+    return iostream
+
+
+def write_schemaless_avro(schema, record, num_records, runs):
+    iostream = BytesIO()
+
+    schema = avro.schema.make_avsc_object(schema)
+    avro_encoder = avro.io.BinaryEncoder(iostream)
+    datum_writer = avro.io.DatumWriter(schema)
+
+    duration = timeit.repeat("""
+iostream.seek(0)
+datum_writer.write(record, avro_encoder)
+""",
+                             number=num_records,
+                             repeat=runs,
+                             globals=locals())
+    print(
+        TIMEIT_FORMAT.format("write schemaless avro", num_records, runs,
+                             min(duration) * 1e3))
+    return iostream
+
+
+def validater(schema, record, num_records, runs):
+    schema = fastavro.parse_schema(schema)
+    records = [record] * num_records
+    validate_many = fastavro.validation.validate_many
+    duration = timeit.repeat("validate_many(records, schema);",
+                             number=1,
+                             repeat=runs,
+                             globals=locals())
+    print(
+        TIMEIT_FORMAT.format("validate fastavro", num_records, runs,
+                             min(duration) * 1e3))
+    return validate_many(records, schema)
+
+
+def read(iostream, num_records, runs):
+    reader = fastavro.reader
+    duration = timeit.repeat("iostream.seek(0);"
+                             "[*reader(iostream)];",
+                             number=1,
+                             repeat=runs,
+                             globals=locals())
+    print(
+        TIMEIT_FORMAT.format("read  fastavro", num_records, runs,
+                             min(duration) * 1e3))
+    iostream.seek(0)
+    return [*reader(iostream)]
+
+
+def read_avro(iostream, num_records, runs):
+    avro_reader = avro.datafile.DataFileReader
+    datum_reader = avro.io.DatumReader()
+
+    duration = timeit.repeat(
+        "iostream.seek(0);"
+        "[*avro_reader(iostream, datum_reader)];",
+        number=1,
+        repeat=runs,
+        globals=locals())
+    print(
+        TIMEIT_FORMAT.format("read  avro", num_records, runs,
+                             min(duration) * 1e3))
+    iostream.seek(0)
+    return [*avro_reader(iostream, datum_reader)]
+
+
+def read_schemaless(iostream, schema, num_records, runs):
+    schema = fastavro.parse_schema(schema)
+    schemaless_reader = fastavro.schemaless_reader
+    duration = timeit.repeat(
+        "iostream.seek(0);"
+        "schemaless_reader(iostream, schema);",
+        number=num_records,
+        repeat=runs,
+        globals=locals())
+    print(
+        TIMEIT_FORMAT.format("read  schemaless fastavro", num_records, runs,
+                             min(duration) * 1e3))
+    iostream.seek(0)
+    return schemaless_reader(iostream, schema)
+
+
+def read_schemaless_avro(iostream, schema, num_records, runs):
+    schema = avro.schema.make_avsc_object(schema)
+    avro_decoder = avro.io.BinaryDecoder(iostream)
+    datum_reader = avro.io.DatumReader(schema)
+
+    duration = timeit.repeat(
+        "iostream.seek(0);"
+        "datum_reader.read(avro_decoder);",
+        number=num_records,
+        repeat=runs,
+        globals=locals())
+    print(
+        TIMEIT_FORMAT.format("read  schemaless avro", num_records, runs,
+                             min(duration) * 1e3))
+    iostream.seek(0)
+    return datum_reader.read(avro_decoder)
+
+
+def test_case(name,
+              schema,
+              record,
+              num_records,
+              num_runs,
+              run_avro=True,
+              test_record=None):
+    print("\n{:25} {:6} records, best of {:6}\n{:=>56}".format(
+        name, num_records, num_runs, '='))
+
+    if test_record is None:
+        test_record = record
+
+    if run_avro:
+        avro_bytesio = write_avro(schema, record, num_records, runs=num_runs)
+    fastavro_bytesio = write(schema, record, num_records, runs=num_runs)
+
+    if run_avro:
+        avro_records = read_avro(avro_bytesio, num_records, runs=num_runs)
+        assert avro_records == [test_record] * num_records
+    fastavro_records = read(fastavro_bytesio, num_records, runs=num_runs)
+    assert fastavro_records == [test_record] * num_records
+
+    if run_avro:
+        avro_bytesio = write_schemaless_avro(schema,
+                                             record,
+                                             num_records,
+                                             runs=num_runs)
+    fastavro_bytesio = write_schemaless(schema,
+                                        record,
+                                        num_records,
+                                        runs=num_runs)
+
+    if run_avro:
+        avro_record = read_schemaless_avro(avro_bytesio,
+                                           schema,
+                                           num_records,
+                                           runs=num_runs)
+        assert avro_record == test_record
+    fastavro_record = read_schemaless(fastavro_bytesio,
+                                      schema,
+                                      num_records,
+                                      runs=num_runs)
+    assert fastavro_record == test_record
+
+    assert validater(schema, record, num_records, runs=num_runs)
+
+
+small_schema = {
+    "type": "record",
+    "name": "Test",
+    "namespace": "test",
+    "fields": [{
+        "name": "field",
+        "type": {
+            "type": "string"
+        }
+    }]
+}
+
+big_schema = {
+    "type":
+    "record",
+    "name":
+    "userInfo",
+    "namespace":
+    "my.example",
+    "fields": [{
+        "name": "username",
+        "type": "string",
+        "default": "NONE"
+    }, {
+        "name": "age",
+        "type": "int",
+        "default": -1
+    }, {
+        "name": "phone",
+        "type": "string",
+        "default": "NONE"
+    }, {
+        "name": "housenum",
+        "type": "string",
+        "default": "NONE"
+    }, {
+        "name": "address",
+        "type": {
+            "type":
+            "record",
+            "name":
+            "mailing_address",
+            "fields": [{
+                "name": "street",
+                "type": "string",
+                "default": "NONE"
+            }, {
+                "name": "city",
+                "type": "string",
+                "default": "NONE"
+            }, {
+                "name": "state_prov",
+                "type": "string",
+                "default": "NONE"
+            }, {
+                "name": "country",
+                "type": "string",
+                "default": "NONE"
+            }, {
+                "name": "zip",
+                "type": "string",
+                "default": "NONE"
+            }]
+        },
+        "default": {}
+    }]
+}
+
+timestamp_schema = {
+    "fields": [
+        {
+            "name": "timestamp-micros",
+            "type": {
+                "type": "long",
+                "logicalType": "timestamp-micros"
+            }
+        },
+    ],
+    "namespace":
+    "namespace",
+    "name":
+    "name",
+    "type":
+    "record"
+}
+
+array_schema = {"type": "array", "items": "int"}
+
+small_record = {"field": "foo"}
+big_record = {
+    "username": "username",
+    "age": 10,
+    "phone": "000000000",
+    "housenum": "0000",
+    "address": {
+        "street": "street",
+        "city": "city",
+        "state_prov": "state_prov",
+        "country": "country",
+        "zip": "zip",
+    },
+}
+
+timestamp_record = {
+    "timestamp-micros": datetime.datetime.now().replace(tzinfo=utc),
+}
+
+list_record = [*range(-512, 512)]
+array_record = array.array("i", range(-512, 512))
+
+if __name__ == "__main__":
+    test_case("Small", small_schema, small_record, 1, 100000)
+    test_case("Small", small_schema, small_record, 100, 1000)
+    test_case("Small", small_schema, small_record, 10000, 10)
+    test_case("Big", big_schema, big_record, 1, 100000)
+    test_case("Big", big_schema, big_record, 100, 1000)
+    test_case("Big", big_schema, big_record, 10000, 10)
+    test_case("Timestamp", timestamp_schema, timestamp_record, 1000, 10)
+    test_case("Array from list", array_schema, list_record, 100, 10)
+    test_case("Array from list",
+              array_schema,
+              list_record,
+              100,
+              100,
+              run_avro=False)
+    test_case("Array from array",
+              array_schema,
+              array_record,
+              100,
+              100,
+              test_record=list_record,
+              run_avro=False)

--- a/fastavro/_validation.pyx
+++ b/fastavro/_validation.pyx
@@ -41,7 +41,7 @@ cdef inline bint validate_string(datum):
 
 
 cdef inline bint validate_bytes(datum):
-    return isinstance(datum, bytes)
+    return isinstance(datum, (bytes, bytearray))
 
 
 cdef inline bint validate_int(datum):

--- a/fastavro/_validation.pyx
+++ b/fastavro/_validation.pyx
@@ -1,5 +1,6 @@
 # cython: language_level=3str
 
+import array
 import numbers
 try:
     from collections.abc import Mapping, Sequence
@@ -84,7 +85,7 @@ cdef inline bint validate_array(
     str parent_ns='',
     bint raise_errors=True,
 ) except -1:
-    if not isinstance(datum, Sequence) or is_str(datum):
+    if not isinstance(datum, (Sequence, array.array)) or is_str(datum):
         return False
 
     for d in datum:

--- a/fastavro/_validation_py.py
+++ b/fastavro/_validation_py.py
@@ -72,7 +72,7 @@ def validate_bytes(datum, **kwargs):
     kwargs: Any
         Unused kwargs
     """
-    return isinstance(datum, bytes)
+    return isinstance(datum, (bytes, bytearray))
 
 
 def validate_int(datum, **kwargs):

--- a/fastavro/_validation_py.py
+++ b/fastavro/_validation_py.py
@@ -1,3 +1,4 @@
+import array
 import numbers
 try:
     from collections.abc import Mapping, Sequence
@@ -196,7 +197,7 @@ def validate_array(
         If true, raises ValidationError on invalid data
     """
     return (
-            isinstance(datum, Sequence) and
+            isinstance(datum, (Sequence, array.array)) and
             not is_str(datum) and
             all(_validate(datum=d, schema=schema['items'],
                           named_schemas=named_schemas,

--- a/fastavro/_write.pyx
+++ b/fastavro/_write.pyx
@@ -114,7 +114,7 @@ cdef inline write_double(bytearray fo, double datum):
     fo += ch_temp[:8]
 
 
-cdef inline write_bytes(bytearray fo, bytes datum):
+cdef inline write_bytes(bytearray fo, const unsigned char[:] datum):
     """Bytes are encoded as a long followed by that many bytes of data."""
     write_long(fo, len(datum))
     fo += datum
@@ -123,7 +123,9 @@ cdef inline write_bytes(bytearray fo, bytes datum):
 cdef inline write_utf8(bytearray fo, datum):
     """A string is encoded as a long followed by that many bytes of UTF-8
     encoded character data."""
-    write_bytes(fo, utob(datum))
+    b_datum = utob(datum)
+    write_long(fo, len(b_datum))
+    fo += b_datum
 
 
 cdef inline write_crc32(bytearray fo, bytes bytes):

--- a/fastavro/_write.pyx
+++ b/fastavro/_write.pyx
@@ -55,7 +55,7 @@ cdef inline write_int(bytearray fo, datum):
     """
     cdef ulong64 n
     cdef unsigned char ch_temp[1]
-    n = (datum << 1) ^ (datum >> 63)
+    n = ~(datum << 1) if datum < 0 else (datum << 1)
     while (n & ~0x7F) != 0:
         ch_temp[0] = (n & 0x7f) | 0x80
         fo += ch_temp[:1]

--- a/fastavro/_write.pyx
+++ b/fastavro/_write.pyx
@@ -50,7 +50,7 @@ cdef inline write_boolean(bytearray fo, bint datum):
     fo += ch_temp[:1]
 
 
-cdef inline write_int(bytearray fo, long long datum):
+cdef inline write_int(bytearray fo, long64 datum):
     """int and long values are written using variable-length, zig-zag coding.
     """
     cdef ulong64 n

--- a/fastavro/_write.pyx
+++ b/fastavro/_write.pyx
@@ -182,14 +182,14 @@ cdef write_python_array(bytearray fo,
         write_long(fo, len(datum))
         record_type = extract_record_type(schema['items'])
         if record_type in ('int', 'long'):
-            for idx in range(len(datum)):
-                write_int(fo, datum[idx])
+            for item in datum:
+                write_int(fo, item)
         elif record_type == 'float':
-            for idx in range(len(datum)):
-                write_float(fo, datum[idx])
+            for item in datum:
+                write_float(fo, item)
         elif record_type == 'double':
-            for idx in range(len(datum)):
-                write_double(fo, datum[idx])
+            for item in datum:
+                write_double(fo, item)
         else:
             dtype = schema['items']
             for item in datum:

--- a/fastavro/_write.pyx
+++ b/fastavro/_write.pyx
@@ -172,7 +172,11 @@ cdef write_array(bytearray fo, list datum, schema, dict named_schemas, fname):
     write_long(fo, 0)
 
 
-cdef write_python_array(bytearray fo, array.array datum, schema, named_schemas):
+cdef write_python_array(bytearray fo,
+                        array.array datum,
+                        schema,
+                        named_schemas,
+                        fname):
     """Array specialization for python arrays."""
     if len(datum) > 0:
         write_long(fo, len(datum))
@@ -189,7 +193,7 @@ cdef write_python_array(bytearray fo, array.array datum, schema, named_schemas):
         else:
             dtype = schema['items']
             for item in datum:
-                write_data(fo, item, dtype, named_schemas)
+                write_data(fo, item, dtype, named_schemas, fname)
     write_long(fo, 0)
 
 
@@ -358,7 +362,9 @@ cpdef write_data(bytearray fo, datum, schema, dict named_schemas, fname):
             return write_enum(fo, datum, schema, named_schemas)
         elif record_type == 'array':
             if isinstance(datum, array.array):
-                return write_python_array(fo, datum, schema, named_schemas)
+                return write_python_array(
+                    fo, datum, schema, named_schemas, fname
+                )
             elif not isinstance(datum, list):
                 datum = list(datum)
             return write_array(fo, datum, schema, named_schemas, fname)

--- a/fastavro/_write.pyx
+++ b/fastavro/_write.pyx
@@ -50,12 +50,12 @@ cdef inline write_boolean(bytearray fo, bint datum):
     fo += ch_temp[:1]
 
 
-cdef inline write_int(bytearray fo, datum):
+cdef inline write_int(bytearray fo, long long datum):
     """int and long values are written using variable-length, zig-zag coding.
     """
     cdef ulong64 n
     cdef unsigned char ch_temp[1]
-    n = ~(datum << 1) if datum < 0 else (datum << 1)
+    n = (datum << 1) ^ (datum >> 63)
     while (n & ~0x7F) != 0:
         ch_temp[0] = (n & 0x7f) | 0x80
         fo += ch_temp[:1]

--- a/tests/test_complex.py
+++ b/tests/test_complex.py
@@ -134,7 +134,7 @@ def test_array_from_tuple():
 def test_array_from_array():
     schema = {"type": "array", "items": "int"}
     using_list = serialize(schema, [1, -2, 3])
-    using_array = serialize(schema, array.array("q", [1, -2, 3]))
+    using_array = serialize(schema, array.array("l", [1, -2, 3]))
     assert using_list == using_array
     assert deserialize(schema, using_list) == [1, -2, 3]
 

--- a/tests/test_complex.py
+++ b/tests/test_complex.py
@@ -1,3 +1,4 @@
+import array
 import datetime
 from decimal import Decimal
 from io import BytesIO
@@ -128,3 +129,11 @@ def test_array_from_tuple():
     data_list = serialize({"type": "array", "items": "int"}, [1, 2, 3])
     data_tuple = serialize({"type": "array", "items": "int"}, (1, 2, 3))
     assert data_list == data_tuple
+
+
+def test_array_from_array():
+    schema = {"type": "array", "items": "int"}
+    using_list = serialize(schema, [1, -2, 3])
+    using_array = serialize(schema, array.array("q", [1, -2, 3]))
+    assert using_list == using_array
+    assert deserialize(schema, using_list) == [1, -2, 3]

--- a/tests/test_complex.py
+++ b/tests/test_complex.py
@@ -137,3 +137,11 @@ def test_array_from_array():
     using_array = serialize(schema, array.array("q", [1, -2, 3]))
     assert using_list == using_array
     assert deserialize(schema, using_list) == [1, -2, 3]
+
+
+def test_bytes_from_bytearray():
+    schema = {"type": "bytes"}
+    using_bytes = serialize(schema, b"\x00\xf1\x02")
+    using_bytearray = serialize(schema, bytearray(b"\x00\xf1\x02"))
+    assert using_bytes == using_bytearray
+    assert deserialize(schema, using_bytes) == b"\x00\xf1\x02"

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -92,3 +92,24 @@ def test_int_in_string_raises():
     # Raises AttributeError on py2 and TypeError on py3
     with pytest.raises((TypeError, AttributeError)):
         serialize(schema, *records)
+
+
+def test_int_bytes():
+    test_cases = [(0, b"\x00"),
+                  (-1, b"\x01"), (1, b"\x02"),
+                  (-2, b"\x03"), (2, b"\x04"),
+                  (2147483647, b"\xfe\xff\xff\xff\x0f"),
+                  (-2147483648, b"\xff\xff\xff\xff\x0f"),
+                  (9223372036854775807,
+                   b"\xfe\xff\xff\xff\xff\xff\xff\xff\xff\x01"),
+                  (-9223372036854775808,
+                   b"\xff\xff\xff\xff\xff\xff\xff\xff\xff\x01")
+                  ]
+
+    schema = {"type": "long"}
+
+    for value, encoded in test_cases:
+        buffer = BytesIO()
+        fastavro.schemaless_writer(buffer, schema, value)
+        serialized = buffer.getvalue()
+        assert serialized == encoded, "Invalid integer encoding encountered."


### PR DESCRIPTION
First of all, sorry for adding too many items in one PR.  They're well separated in commits, so I can easily drop one or more parts.
As a second remark, I should probably add I have no experience with cython, so I'll be happy to read your comments.

The first change allows for python's `array.array` to be serialized to an array.
The second change allows for a `bytearray` to be serialized to bytes.  I had to move some logic to `write_utf8` to avoid performance loss.
The last commit introduces a small change in `write_int`, that improves cython performance for me.

I also added a `timeit`-based benchmark, to easily follow up the effects:

original:
```
Array from list                   100 records, best of   1000
========================================================
write fastavro               100 records, best of   1000:  14.400871 ms
read  fastavro               100 records, best of   1000:  15.655241 ms
write schemaless fastavro    100 records, best of   1000:  14.669046 ms
read  schemaless fastavro    100 records, best of   1000:  13.781189 ms
validate fastavro            100 records, best of   1000:  15.007082 ms

real    1m16.688s
user    1m15.806s
sys     0m0.705s
```

after array.array and bytearray addition:
```
Array from list                   100 records, best of   1000
========================================================
write fastavro               100 records, best of   1000:  14.400178 ms
read  fastavro               100 records, best of   1000:  15.634401 ms
write schemaless fastavro    100 records, best of   1000:  14.759453 ms
read  schemaless fastavro    100 records, best of   1000:  13.944073 ms
validate fastavro            100 records, best of   1000:  15.596337 ms

real    1m20.245s
user    1m19.191s
sys     0m0.752s
```

after write_int change:
```
Array from list              100 records, best of   1000
========================================================
write fastavro               100 records, best of   1000:  11.314640 ms
read  fastavro               100 records, best of   1000:  15.760850 ms
write schemaless fastavro    100 records, best of   1000:  11.621763 ms
read  schemaless fastavro    100 records, best of   1000:  13.935867 ms
validate fastavro            100 records, best of   1000:  15.673204 ms

real    1m11.119s
user    1m10.324s
sys     0m0.626s
```

array.array vs list:
```
Array from list              100 records, best of    100
========================================================
write fastavro               100 records, best of    100:  11.315835 ms
read  fastavro               100 records, best of    100:  15.406354 ms
write schemaless fastavro    100 records, best of    100:  11.669317 ms
read  schemaless fastavro    100 records, best of    100:  14.000947 ms
validate fastavro            100 records, best of    100:  15.810282 ms

Array from array             100 records, best of    100
========================================================
write fastavro               100 records, best of    100:   9.927711 ms
read  fastavro               100 records, best of    100:  15.353774 ms
write schemaless fastavro    100 records, best of    100:  10.219035 ms
read  schemaless fastavro    100 records, best of    100:  14.010455 ms
validate fastavro            100 records, best of    100:  17.267594 ms
```


Validation for python arrays is slower than for lists, and could be improved for specific cases based on `array.itemsize` and signedness and/or cython memoryviews.

Finally, `write_python_array` probably could be improved by also adding cases where for example `float` isn't the exact type, but part of a union.