### PR TITLE
allow bytes in standalone fastavro output

### DIFF
--- a/fastavro/_six.pyx
+++ b/fastavro/_six.pyx
@@ -24,8 +24,8 @@ if sys.version_info >= (3, 0):
     def py3_utob(n, encoding=_encoding):
         return bytes(n, encoding)
 
-    def py3_json_dump(obj, indent):
-        json.dump(obj, sys.stdout, indent=indent)
+    def py3_json_dump(obj, **kwargs):
+        json.dump(obj, sys.stdout, **kwargs)
 
     def py3_iterkeys(obj):
         return obj.keys()
@@ -88,10 +88,7 @@ else:  # Python 2x
 
     _outenc = getattr(sys.stdout, 'encoding', None) or _encoding
 
-    def py2_json_dump(obj, indent):
-        kwargs = {}
-        if indent is not None:
-            kwargs['indent'] = indent
+    def py2_json_dump(obj, **kwargs):
         json.dump(obj, sys.stdout, encoding=_outenc, **kwargs)
 
     def py2_iterkeys(obj):

--- a/fastavro/six.py
+++ b/fastavro/six.py
@@ -23,8 +23,8 @@ if sys.version_info >= (3, 0):
     def py3_utob(n, encoding=_encoding):
         return bytes(n, encoding)
 
-    def py3_json_dump(obj, indent):
-        json.dump(obj, sys.stdout, indent=indent)
+    def py3_json_dump(obj, **kwargs):
+        json.dump(obj, sys.stdout, **kwargs)
 
     def py3_iterkeys(obj):
         return obj.keys()
@@ -86,10 +86,7 @@ else:  # Python 2x
 
     _outenc = getattr(sys.stdout, 'encoding', None) or _encoding
 
-    def py2_json_dump(obj, indent):
-        kwargs = {}
-        if indent is not None:
-            kwargs['indent'] = indent
+    def py2_json_dump(obj, **kwargs):
         json.dump(obj, sys.stdout, encoding=_outenc, **kwargs)
 
     def py2_iterkeys(obj):

--- a/tests/test_logical_types.py
+++ b/tests/test_logical_types.py
@@ -1,5 +1,6 @@
 import fastavro
 from fastavro.__main__ import CleanJSONEncoder
+from fastavro.six import btou
 from fastavro._timezone import epoch
 import json
 import pytest
@@ -327,12 +328,14 @@ def test_clean_json_list():
         datetime.date.today(),
         uuid4(),
         Decimal('1.23'),
+        bytes(b"\x00\x01\x61\xff"),
     ]
     str_values = [
         values[0].isoformat(),
         values[1].isoformat(),
         str(values[2]),
         str(values[3]),
+        btou(values[4], encoding='iso-8859-1'),
     ]
     assert (json.dumps(values, cls=CleanJSONEncoder) ==
             json.dumps(str_values, cls=CleanJSONEncoder))
@@ -344,12 +347,14 @@ def test_clean_json_dict():
         '2': datetime.date.today(),
         '3': uuid4(),
         '4': Decimal('1.23'),
+        '5': bytes(b"\x00\x01\x61\xff"),
     }
     str_values = {
         '1': values['1'].isoformat(),
         '2': values['2'].isoformat(),
         '3': str(values['3']),
         '4': str(values['4']),
+        '5': btou(values['5'], encoding='iso-8859-1'),
     }
     assert (json.dumps(values, cls=CleanJSONEncoder) ==
             json.dumps(str_values, cls=CleanJSONEncoder))

--- a/tests/test_logical_types.py
+++ b/tests/test_logical_types.py
@@ -1,6 +1,7 @@
 import fastavro
-from fastavro.__main__ import _clean_json_record
+from fastavro.__main__ import CleanJSONEncoder
 from fastavro._timezone import epoch
+import json
 import pytest
 
 from decimal import Decimal
@@ -333,8 +334,8 @@ def test_clean_json_list():
         str(values[2]),
         str(values[3]),
     ]
-    _clean_json_record(values)
-    assert values == str_values
+    assert (json.dumps(values, cls=CleanJSONEncoder) ==
+            json.dumps(str_values, cls=CleanJSONEncoder))
 
 
 def test_clean_json_dict():
@@ -350,8 +351,8 @@ def test_clean_json_dict():
         '3': str(values['3']),
         '4': str(values['4']),
     }
-    _clean_json_record(values)
-    assert values == str_values
+    assert (json.dumps(values, cls=CleanJSONEncoder) ==
+            json.dumps(str_values, cls=CleanJSONEncoder))
 
 
 def test_unknown_logical_type():

--- a/tests/test_logical_types.py
+++ b/tests/test_logical_types.py
@@ -328,7 +328,7 @@ def test_clean_json_list():
         datetime.date.today(),
         uuid4(),
         Decimal('1.23'),
-        bytes(b"\x00\x01\x61\xff"),
+        bytes(b"5"),
     ]
     str_values = [
         values[0].isoformat(),
@@ -347,7 +347,7 @@ def test_clean_json_dict():
         '2': datetime.date.today(),
         '3': uuid4(),
         '4': Decimal('1.23'),
-        '5': bytes(b"\x00\x01\x61\xff"),
+        '5': bytes(b"5"),
     }
     str_values = {
         '1': values['1'].isoformat(),


### PR DESCRIPTION
Sorry for getting back so fast, as you can tell I'm looking at binary data.

The output of `bytes` was missing for the standalone `fastavro` command.
Extending `JSONEncoder` also simplifies the code a bit.
