### PR TITLE
Set python_requires='>=3.5'

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -95,7 +95,7 @@ setup(
         'Topic :: Software Development :: Libraries',
         'Topic :: Scientific/Engineering :: Information Analysis',
     ],
-    python_requires='>=3.5',
+    python_requires='>=3.0',
     extras_require={
         'codecs': ['python-snappy', 'zstandard', 'lz4', 'backports.lzma'],
         'snappy': ['python-snappy'],

--- a/setup.py
+++ b/setup.py
@@ -95,6 +95,7 @@ setup(
         'Topic :: Software Development :: Libraries',
         'Topic :: Scientific/Engineering :: Information Analysis',
     ],
+    python_requires='>=3.5',
     extras_require={
         'codecs': ['python-snappy', 'zstandard', 'lz4', 'backports.lzma'],
         'snappy': ['python-snappy'],


### PR DESCRIPTION
From your changelog seems like in the latest version you dropped Python 2 support but it is incomplete.  You need to set `python_requires` in your setup.py that will prevent users with Python 2.7 from downloading a sdist version they cannot build.

Note: supporting python_requires requires setuptools>=24.2.0 and pip>=9.0.0 to benefit from it.
Details here: https://packaging.python.org/guides/distributing-packages-using-setuptools/#python-requires