### PR TITLE
Apply logical type preparation when checking for best union type

### DIFF
--- a/fastavro/_write.pyx
+++ b/fastavro/_write.pyx
@@ -295,15 +295,14 @@ cdef write_union(bytearray fo, datum, schema, dict named_schemas, fname):
                     continue
 
             if _validate(datum, candidate, named_schemas, raise_errors=False):
-                if isinstance(candidate, dict):
+                record_type = extract_record_type(candidate)
+                if record_type == "record":
                     logical_type = extract_logical_type(candidate)
                     if logical_type:
                         prepare = LOGICAL_WRITERS.get(logical_type)
                         if prepare:
                             datum = prepare(datum, candidate)
 
-                record_type = extract_record_type(candidate)
-                if record_type == "record":
                     candidate_fields = set(
                         f["name"] for f in candidate["fields"]
                     )

--- a/fastavro/_write.pyx
+++ b/fastavro/_write.pyx
@@ -295,6 +295,13 @@ cdef write_union(bytearray fo, datum, schema, dict named_schemas, fname):
                     continue
 
             if _validate(datum, candidate, named_schemas, raise_errors=False):
+                if isinstance(candidate, dict):
+                    logical_type = extract_logical_type(candidate)
+                    if logical_type:
+                        prepare = LOGICAL_WRITERS.get(logical_type)
+                        if prepare:
+                            datum = prepare(datum, candidate)
+
                 record_type = extract_record_type(candidate)
                 if record_type == "record":
                     candidate_fields = set(

--- a/fastavro/_write_py.py
+++ b/fastavro/_write_py.py
@@ -183,15 +183,14 @@ def write_union(encoder, datum, schema, named_schemas, fname):
                     continue
 
             if _validate(datum, candidate, named_schemas, raise_errors=False):
-                if isinstance(candidate, dict):
+                record_type = extract_record_type(candidate)
+                if record_type == "record":
                     logical_type = extract_logical_type(candidate)
                     if logical_type:
                         prepare = LOGICAL_WRITERS.get(logical_type)
                         if prepare:
                             datum = prepare(datum, candidate)
 
-                record_type = extract_record_type(candidate)
-                if record_type == "record":
                     candidate_fields = set(f["name"] for f in candidate["fields"])
                     datum_fields = set(datum)
                     fields = len(candidate_fields.intersection(datum_fields))

--- a/fastavro/_write_py.py
+++ b/fastavro/_write_py.py
@@ -183,6 +183,13 @@ def write_union(encoder, datum, schema, named_schemas, fname):
                     continue
 
             if _validate(datum, candidate, named_schemas, raise_errors=False):
+                if isinstance(candidate, dict):
+                    logical_type = extract_logical_type(candidate)
+                    if logical_type:
+                        prepare = LOGICAL_WRITERS.get(logical_type)
+                        if prepare:
+                            datum = prepare(datum, candidate)
+
                 record_type = extract_record_type(candidate)
                 if record_type == "record":
                     candidate_fields = set(f["name"] for f in candidate["fields"])

--- a/tests/test_logical_types.py
+++ b/tests/test_logical_types.py
@@ -484,8 +484,6 @@ class Interface:
 
 
 def read_ndarray(data, writer_schema, reader_schema):
-    import numpy as np
-
     return np.array(Interface(data))
 
 


### PR DESCRIPTION
Previously validate would pass (and it does the prepare step) but then the datum was still pre preparation when it tried to do anything further. 
As far as I can tell this only really matters for record types, but made more general in case there was an edge case I was missing. 

The provided test shows this for an ndarray record type which would fail because set(ndarray) does not work [well, it actually does for 1D arrays, but not 2+ dimensional arrays... even in the 1d case it was doing something funky that technically worked, but only on accident]