### PR TITLE
allow decompressing zstandard stream blocks

### DIFF
--- a/fastavro/_read.pyx
+++ b/fastavro/_read.pyx
@@ -945,7 +945,7 @@ else:
 cpdef zstandard_read_block(fo):
     length = read_long(fo)
     data = fo.read(length)
-    return BytesIO(zstd.ZstdDecompressor().decompress(data))
+    return BytesIO(zstd.ZstdDecompressor().decompressobj().decompress(data))
 
 
 try:

--- a/fastavro/_read_py.py
+++ b/fastavro/_read_py.py
@@ -768,7 +768,7 @@ else:
 def zstandard_read_block(decoder):
     length = read_long(decoder)
     data = decoder.read_fixed(length)
-    return BytesIO(zstd.ZstdDecompressor().decompress(data))
+    return BytesIO(zstd.ZstdDecompressor().decompressobj().decompress(data))
 
 
 try:

--- a/tests/test_compression.py
+++ b/tests/test_compression.py
@@ -166,7 +166,7 @@ def test_zstandard_decompress_stream():
         b'Obj\x01\x04\x14avro.codec\x12zstandard\x16avro.schema\xc6\x01{"name"'
         + b':"Weather","namespace":"test","type":"record","fields":[{"name":"s'
         + b'tation","type":"string"}]}\x001234567890123456\x02\x1c(\xb5/\xfd\x00'
-        + b'X)\x00\x00\x08AAAA1234567890123456'
+        + b"X)\x00\x00\x08AAAA1234567890123456"
     )
 
     file = BytesIO(binary)

--- a/tests/test_compression.py
+++ b/tests/test_compression.py
@@ -158,3 +158,17 @@ def test_compression_level(codec):
     file.seek(0)
     out_records = list(fastavro.reader(file))
     assert records == out_records
+
+
+def test_zstandard_decompress_stream():
+    """https://github.com/fastavro/fastavro/pull/575"""
+    binary = (
+        b'Obj\x01\x04\x14avro.codec\x12zstandard\x16avro.schema\xc6\x01{"name"'
+        + b':"Weather","namespace":"test","type":"record","fields":[{"name":"s'
+        + b'tation","type":"string"}]}\x001234567890123456\x02\x1c(\xb5/\xfd\x00'
+        + b'X)\x00\x00\x08AAAA1234567890123456'
+    )
+
+    file = BytesIO(binary)
+    out_records = list(fastavro.reader(file))
+    assert [{"station": "AAAA"}] == out_records


### PR DESCRIPTION
The zstandard stream API produces zstd frames that don't contain the
uncompressed frame size. `zstd.ZstdDecompressor().decompress(data)` is not able to decompress these frames:

```
~>  python
Python 3.9.7 (default, Oct 10 2021, 15:13:22)
>>> import zstandard as zstd
>>> data = b"(\265/\375\x00X)\x00\x00\bAAAA"
>>> zstd.ZstdDecompressor().decompress(data)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
zstd.ZstdError: could not determine content size in frame header
```

The stream-API, however, works:

```
>>> obj = zstd.ZstdDecompressor().decompressobj()
>>> obj.decompress(data)
b'\x08AAAA'
```

I cannot find a reference to streaming APIs vs non-streaming APIs in
the Avro specification, and I suppose the intention is to support
both. The official `avro` for Python does support streaming zstd
frames.

On the compressing side of things, a similar approach may be
appropriate, as this would consume less memory (the uncompressed data wouldn't need to be in memory). However, I don't know if there are any disadvantages so I'm leaving that out.

---
```
~> echo T2JqAQQUYXZyby5jb2RlYxJ6c3RhbmRhcmQWYXZyby5zY2hlbWHGAXsibmFtZSI6IldlYXRoZXIiLCJuYW1lc3BhY2UiOiJ0ZXN0IiwidHlwZSI6InJlY29yZCIsImZpZWxkcyI6W3sibmFtZSI6InN0YXRpb24iLCJ0eXBlIjoic3RyaW5nIn1dfQAxMjM0NTY3ODkwMTIzNDU2AhwotS/9AFgpAAAIQUFBQTEyMzQ1Njc4OTAxMjM0NTY= | base64 -d | fastavro
Traceback (most recent call last):
  File "/home/klm/.local/bin/fastavro", line 8, in <module>
    sys.exit(main())
  File "/home/klm/.local/lib/python3.9/site-packages/fastavro/__main__.py", line 80, in main
    for record in reader:
  File "fastavro/_read.pyx", line 993, in _iter_avro_records
  File "fastavro/_read.pyx", line 945, in fastavro._read.zstandard_read_block
  File "fastavro/_read.pyx", line 948, in fastavro._read.zstandard_read_block
zstd.ZstdError: could not determine content size in frame header
```

Now, with this patch:

```
~> echo T2JqAQQUYXZyby5jb2RlYxJ6c3RhbmRhcmQWYXZyby5zY2hlbWHGAXsibmFtZSI6IldlYXRoZXIiLCJuYW1lc3BhY2UiOiJ0ZXN0IiwidHlwZSI6InJlY29yZCIsImZpZWxkcyI6W3sibmFtZSI6InN0YXRpb24iLCJ0eXBlIjoic3RyaW5nIn1dfQAxMjM0NTY3ODkwMTIzNDU2AhwotS/9AFgpAAAIQUFBQTEyMzQ1Njc4OTAxMjM0NTY= | base64 -d | fastavro
{"station": "AAAA"}
```