### PR TITLE
Add schema repository layer

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -15,6 +15,7 @@ recursive-include docs *.rst
 recursive-include docs Makefile
 recursive-include fastavro *.pyx
 recursive-include fastavro *.pyi
+recursive-include fastavro *.py
 recursive-include fastavro py.typed
 recursive-include tests *.avro
 recursive-include tests *.avsc

--- a/Makefile
+++ b/Makefile
@@ -40,3 +40,8 @@ docs:
 	cd docs && make html
 
 .PHONY: all clean fresh publish test docs
+
+.PHONY: test-docker
+
+test-docker:
+	docker build .

--- a/fastavro/_schema_py.py
+++ b/fastavro/_schema_py.py
@@ -4,9 +4,9 @@ from io import StringIO
 import math
 from os import path
 from copy import deepcopy
-import json
 import re
 
+from .repository import FlatDictRepository, SchemaRepositoryError
 from ._schema_common import (
     PRIMITIVES,
     UnknownType,
@@ -433,18 +433,29 @@ def parse_field(field, namespace, expand, names, named_schemas):
 
 
 def load_schema(
-    schema_path, *, named_schemas=None, _write_hint=True, _injected_schemas=None
+    schema_name,
+    *,
+    repo=None,
+    named_schemas=None,
+    _write_hint=True,
+    _injected_schemas=None,
 ):
-    """Returns a schema loaded from the file at `schema_path`.
+    """Returns a schema loaded from repository.
 
-    Will recursively load referenced schemas assuming they can be found in
-    files in the same directory and named with the convention
-    `<full_name>.avsc`.
+    Will recursively load referenced schemas attempting to load them from
+    same repository.
+
+    If `repo` is not provided, `FlatDictRepository` is used and `schema_name`
+    considered to be a path to schema file. `FlatDictRepository` will try to
+    load schemas from the same directory assuming files are named with the
+    convention `<full_name>.avsc`.
 
     Parameters
     ----------
-    schema: str
-        Path to schema file to load
+    schema_name: str
+        Full schema name, or path to schema file if default repo is used.
+    repo: SchemaRepository
+        Schema repository instance.
     named_schemas: dict
         Dictionary of named schemas to their schema definition
     _write_hint: bool
@@ -454,10 +465,10 @@ def load_schema(
         Internal API argument. Set of names that have been injected
 
 
-    Consider the following example...
+    Consider the following example with default FlatDictRepository...
 
 
-    Parent.avsc::
+    namespace.Parent.avsc::
 
         {
             "type": "record",
@@ -486,45 +497,72 @@ def load_schema(
 
         from fastavro.schema import load_schema
 
-        parsed_schema = load_schema("Parent.avsc")
+        parsed_schema = load_schema("namespace.Parent.avsc")
     """
+    if repo is None:
+        file_path = schema_name
+        file_dir, file_name = path.split(file_path)
+        schema_name, _file_ext = path.splitext(file_name)
+        repo = FlatDictRepository(file_dir)
+
     if named_schemas is None:
         named_schemas = {}
 
     if _injected_schemas is None:
         _injected_schemas = set()
 
-    with open(schema_path) as fd:
-        schema = json.load(fd)
-    schema_dir, schema_file = path.split(schema_path)
-    return _load_schema(
-        schema, schema_dir, named_schemas, _write_hint, _injected_schemas
-    )
+    schema = repo.load(schema_name)
+    return _load_schema(schema, repo, named_schemas, _write_hint, _injected_schemas)
 
 
-def _load_schema(schema, schema_dir, named_schemas, write_hint, injected_schemas):
+def _load_schema(schema_name, repo, named_schemas, write_hint, injected_schemas):
+    try:
+        schema = repo.load(schema_name)
+        return _parse_schema_with_repo(
+            schema,
+            repo,
+            named_schemas,
+            write_hint,
+            injected_schemas,
+        )
+    except SchemaRepositoryError as error:
+        raise error
+
+
+def _parse_schema_with_repo(
+    schema,
+    repo,
+    named_schemas,
+    write_hint,
+    injected_schemas,
+):
     try:
         schema_copy = deepcopy(named_schemas)
-        return parse_schema(schema, named_schemas=named_schemas, _write_hint=write_hint)
-    except UnknownType as e:
+        return parse_schema(
+            schema,
+            named_schemas=named_schemas,
+            _write_hint=write_hint,
+        )
+    except UnknownType as error:
+        missing_subject = error.name
         try:
-            avsc = path.join(schema_dir, f"{e.name}.avsc")
-            sub_schema = load_schema(
-                avsc,
+            sub_schema = _load_schema(
+                missing_subject,
+                repo,
                 named_schemas=schema_copy,
                 _write_hint=False,
                 _injected_schemas=injected_schemas,
             )
-        except IOError:
-            raise e
+        except SchemaRepositoryError:
+            raise error
 
         if sub_schema["name"] not in injected_schemas:
             injected_schema = _inject_schema(schema, sub_schema)
             if isinstance(schema, str) or isinstance(schema, list):
                 schema = injected_schema[0]
             injected_schemas.add(sub_schema["name"])
-        return _load_schema(
-            schema, schema_dir, schema_copy, write_hint, injected_schemas
+        return _parse_schema_with_repo(
+            schema, repo, schema_copy, write_hint, injected_schemas
         )
 
 

--- a/fastavro/_schema_py.py
+++ b/fastavro/_schema_py.py
@@ -433,7 +433,7 @@ def parse_field(field, namespace, expand, names, named_schemas):
 
 
 def load_schema(
-    schema_name,
+    schema_path,
     *,
     repo=None,
     named_schemas=None,
@@ -443,16 +443,15 @@ def load_schema(
     """Returns a schema loaded from repository.
 
     Will recursively load referenced schemas attempting to load them from
-    same repository.
+    same repository, using `schema_path` as schema name.
 
-    If `repo` is not provided, `FlatDictRepository` is used and `schema_name`
-    considered to be a path to schema file. `FlatDictRepository` will try to
-    load schemas from the same directory assuming files are named with the
-    convention `<full_name>.avsc`.
+    If `repo` is not provided, `FlatDictRepository` is used.
+    `FlatDictRepository` will try to load schemas from the same directory
+    assuming files are named with the convention `<full_name>.avsc`.
 
     Parameters
     ----------
-    schema_name: str
+    schema_path: str
         Full schema name, or path to schema file if default repo is used.
     repo: SchemaRepository
         Schema repository instance.
@@ -499,9 +498,9 @@ def load_schema(
 
         parsed_schema = load_schema("namespace.Parent.avsc")
     """
+    schema_name = schema_path
     if repo is None:
-        file_path = schema_name
-        file_dir, file_name = path.split(file_path)
+        file_dir, file_name = path.split(schema_path)
         schema_name, _file_ext = path.splitext(file_name)
         repo = FlatDictRepository(file_dir)
 

--- a/fastavro/repository/__init__.py
+++ b/fastavro/repository/__init__.py
@@ -1,0 +1,8 @@
+from .base import AbstractSchemaRepository, SchemaRepositoryError
+from .flat_dict import FlatDictRepository
+
+__all__ = [
+    "AbstractSchemaRepository",
+    "FlatDictRepository",
+    "SchemaRepositoryError",
+]

--- a/fastavro/repository/base.py
+++ b/fastavro/repository/base.py
@@ -1,0 +1,11 @@
+from abc import ABC, abstractmethod
+
+
+class SchemaRepositoryError(Exception):
+    pass
+
+
+class AbstractSchemaRepository(ABC):
+    @abstractmethod
+    def load(self, name):
+        pass

--- a/fastavro/repository/flat_dict.py
+++ b/fastavro/repository/flat_dict.py
@@ -4,15 +4,13 @@ from os import path
 from .base import AbstractSchemaRepository, SchemaRepositoryError
 
 
-FILE_EXT = "avsc"
-
-
 class FlatDictRepository(AbstractSchemaRepository):
     def __init__(self, path):
         self.path = path
+        self.file_ext = "avsc"
 
     def load(self, name):
-        file_path = path.join(self.path, f"{name}.{FILE_EXT}")
+        file_path = path.join(self.path, f"{name}.{self.file_ext}")
         try:
             with open(file_path) as schema_file:
                 return json.load(schema_file)

--- a/fastavro/repository/flat_dict.py
+++ b/fastavro/repository/flat_dict.py
@@ -1,0 +1,22 @@
+import json
+from os import path
+
+from .base import AbstractSchemaRepository, SchemaRepositoryError
+
+
+FILE_EXT = "avsc"
+
+
+class FlatDictRepository(AbstractSchemaRepository):
+    def __init__(self, path):
+        self.path = path
+
+    def load(self, name):
+        file_path = path.join(self.path, f"{name}.{FILE_EXT}")
+        try:
+            with open(file_path) as schema_file:
+                return json.load(schema_file)
+        except IOError as error:
+            raise SchemaRepositoryError(
+                f"Failed to load '{name}' schema",
+            ) from error


### PR DESCRIPTION
This moves schema reading to another layer, allowing clients to use custom repositories in case if their schema storage is different from flat directory.