### PR TITLE
Fix logical readers reference

### DIFF
--- a/fastavro/_logical_readers.pyi
+++ b/fastavro/_logical_readers.pyi
@@ -1,0 +1,3 @@
+from typing import Any, Dict, Callable
+
+LOGICAL_READERS: Dict[str, Callable[[Any, Dict], Any]]

--- a/fastavro/_logical_readers.pyx
+++ b/fastavro/_logical_readers.pyx
@@ -1,0 +1,108 @@
+# cython: language_level=3
+# cython: auto_cpdef=True
+
+"""Python code for reading AVRO files"""
+
+# This code is a modified version of the code at
+# http://svn.apache.org/viewvc/avro/trunk/lang/py/src/avro/ which is under
+# Apache 2.0 license (http://www.apache.org/licenses/LICENSE-2.0)
+
+from datetime import datetime, time, date, timezone, timedelta
+from decimal import Context
+from uuid import UUID
+
+from .const import (
+    MCS_PER_HOUR,
+    MCS_PER_MINUTE,
+    MCS_PER_SECOND,
+    MLS_PER_HOUR,
+    MLS_PER_MINUTE,
+    MLS_PER_SECOND,
+    DAYS_SHIFT,
+)
+
+CYTHON_MODULE = 1  # Tests check this to confirm whether using the Cython code.
+
+MASK = 0xFF
+
+decimal_context = Context()
+epoch = datetime(1970, 1, 1, tzinfo=timezone.utc)
+epoch_naive = datetime(1970, 1, 1)
+
+ctypedef int int32
+ctypedef unsigned int uint32
+ctypedef unsigned long long ulong64
+ctypedef long long long64
+
+
+class ReadError(Exception):
+    pass
+
+
+cpdef read_timestamp_millis(data, writer_schema=None, reader_schema=None):
+    # Cannot use datetime.fromtimestamp: https://bugs.python.org/issue36439
+    return epoch + timedelta(microseconds=data * 1000)
+
+
+cpdef read_local_timestamp_millis(data, writer_schema=None, reader_schema=None):
+    # Cannot use datetime.fromtimestamp: https://bugs.python.org/issue36439
+    return epoch_naive + timedelta(microseconds=data * 1000)
+
+
+cpdef read_timestamp_micros(data, writer_schema=None, reader_schema=None):
+    # Cannot use datetime.fromtimestamp: https://bugs.python.org/issue36439
+    return epoch + timedelta(microseconds=data)
+
+
+cpdef read_local_timestamp_micros(data, writer_schema=None, reader_schema=None):
+    # Cannot use datetime.fromtimestamp: https://bugs.python.org/issue36439
+    return epoch_naive + timedelta(microseconds=data)
+
+
+cpdef read_date(data, writer_schema=None, reader_schema=None):
+    return date.fromordinal(data + DAYS_SHIFT)
+
+
+cpdef read_uuid(data, writer_schema=None, reader_schema=None):
+    return UUID(data)
+
+
+cpdef read_decimal(data, writer_schema=None, reader_schema=None):
+    scale = writer_schema.get("scale", 0)
+    precision = writer_schema["precision"]
+
+    unscaled_datum = int.from_bytes(data, byteorder="big", signed=True)
+
+    decimal_context.prec = precision
+    return decimal_context.create_decimal(unscaled_datum).\
+        scaleb(-scale, decimal_context)
+
+
+cpdef read_time_millis(data, writer_schema=None, reader_schema=None):
+    h = int(data / MLS_PER_HOUR)
+    m = int(data / MLS_PER_MINUTE) % 60
+    s = int(data / MLS_PER_SECOND) % 60
+    mls = int(data % MLS_PER_SECOND) * 1000
+    return time(h, m, s, mls)
+
+
+cpdef read_time_micros(data, writer_schema=None, reader_schema=None):
+    h = int(data / MCS_PER_HOUR)
+    m = int(data / MCS_PER_MINUTE) % 60
+    s = int(data / MCS_PER_SECOND) % 60
+    mcs = data % MCS_PER_SECOND
+    return time(h, m, s, mcs)
+
+
+LOGICAL_READERS = {
+    "long-timestamp-millis": read_timestamp_millis,
+    "long-local-timestamp-millis": read_local_timestamp_millis,
+    "long-timestamp-micros": read_timestamp_micros,
+    "long-local-timestamp-micros": read_local_timestamp_micros,
+    "int-date": read_date,
+    "bytes-decimal": read_decimal,
+    "fixed-decimal": read_decimal,
+    "string-uuid": read_uuid,
+    "int-time-millis": read_time_millis,
+    "long-time-micros": read_time_micros,
+}

--- a/fastavro/_logical_readers_py.py
+++ b/fastavro/_logical_readers_py.py
@@ -1,0 +1,94 @@
+# cython: auto_cpdef=True
+
+import datetime
+import time
+import uuid
+from datetime import date, timedelta
+from decimal import Context
+from .const import (
+    MCS_PER_HOUR,
+    MCS_PER_MINUTE,
+    MCS_PER_SECOND,
+    MLS_PER_HOUR,
+    MLS_PER_MINUTE,
+    MLS_PER_SECOND,
+    DAYS_SHIFT,
+)
+
+epoch = datetime.datetime(1970, 1, 1, tzinfo=datetime.timezone.utc)
+epoch_naive = datetime.datetime(1970, 1, 1)
+decimal_context = Context()
+
+
+def read_timestamp_millis(data, writer_schema=None, reader_schema=None):
+    # Cannot use datetime.fromtimestamp: https://bugs.python.org/issue36439
+    return epoch + timedelta(microseconds=data * 1000)
+
+
+def read_local_timestamp_millis(
+    data: int, writer_schema=None, reader_schema=None
+) -> datetime.datetime:
+    # Cannot use datetime.fromtimestamp: https://bugs.python.org/issue36439
+    return epoch_naive + timedelta(microseconds=data * 1000)
+
+
+def read_timestamp_micros(data, writer_schema=None, reader_schema=None):
+    # Cannot use datetime.fromtimestamp: https://bugs.python.org/issue36439
+    return epoch + timedelta(microseconds=data)
+
+
+def read_local_timestamp_micros(
+    data: int, writer_schema=None, reader_schema=None
+) -> datetime.datetime:
+    # Cannot use datetime.fromtimestamp: https://bugs.python.org/issue36439
+    return epoch_naive + timedelta(microseconds=data)
+
+
+def read_date(data, writer_schema=None, reader_schema=None):
+    return date.fromordinal(data + DAYS_SHIFT)
+
+
+def read_uuid(data, writer_schema=None, reader_schema=None):
+    return uuid.UUID(data)
+
+
+def read_decimal(data, writer_schema=None, reader_schema=None):
+    scale = writer_schema.get("scale", 0)
+    precision = writer_schema["precision"]
+
+    unscaled_datum = int.from_bytes(data, byteorder="big", signed=True)
+
+    decimal_context.prec = precision
+    return decimal_context.create_decimal(unscaled_datum).scaleb(
+        -scale, decimal_context
+    )
+
+
+def read_time_millis(data, writer_schema=None, reader_schema=None):
+    h = int(data / MLS_PER_HOUR)
+    m = int(data / MLS_PER_MINUTE) % 60
+    s = int(data / MLS_PER_SECOND) % 60
+    mls = int(data % MLS_PER_SECOND) * 1000
+    return time(h, m, s, mls)
+
+
+def read_time_micros(data, writer_schema=None, reader_schema=None):
+    h = int(data / MCS_PER_HOUR)
+    m = int(data / MCS_PER_MINUTE) % 60
+    s = int(data / MCS_PER_SECOND) % 60
+    mcs = data % MCS_PER_SECOND
+    return time(h, m, s, mcs)
+
+
+LOGICAL_READERS = {
+    "long-timestamp-millis": read_timestamp_millis,
+    "long-local-timestamp-millis": read_local_timestamp_millis,
+    "long-timestamp-micros": read_timestamp_micros,
+    "long-local-timestamp-micros": read_local_timestamp_micros,
+    "int-date": read_date,
+    "bytes-decimal": read_decimal,
+    "fixed-decimal": read_decimal,
+    "string-uuid": read_uuid,
+    "int-time-millis": read_time_millis,
+    "long-time-micros": read_time_micros,
+}

--- a/fastavro/_logical_readers_py.pyi
+++ b/fastavro/_logical_readers_py.pyi
@@ -1,0 +1,3 @@
+from typing import Any, Dict, Callable
+
+LOGICAL_READERS: Dict[str, Callable[[Any, Dict], Any]]

--- a/fastavro/_read.pyi
+++ b/fastavro/_read.pyi
@@ -57,7 +57,6 @@ def schemaless_reader(
 def is_avro(path_or_buffer: Union[str, IO]) -> bool: ...
 
 logical_reader = Callable[[Any, Optional[Dict], Optional[Dict]], Any]
-LOGICAL_READERS: Dict[str, logical_reader]
 
 class SchemaResolutionError(Exception): ...
 

--- a/fastavro/logical_readers.py
+++ b/fastavro/logical_readers.py
@@ -1,0 +1,8 @@
+try:
+    from . import _logical_readers
+except ImportError:
+    from . import _logical_readers_py as _logical_readers  # type: ignore
+
+LOGICAL_READERS = _logical_readers.LOGICAL_READERS
+
+__all__ = ["LOGICAL_READERS"]

--- a/fastavro/read.py
+++ b/fastavro/read.py
@@ -4,6 +4,7 @@ except ImportError:
     from . import _read_py as _read  # type: ignore
 
 from . import json_read
+from . import logical_readers
 from . import _read_common
 
 # Private API
@@ -18,7 +19,7 @@ block_reader = _read.block_reader
 schemaless_reader = _read.schemaless_reader
 json_reader = json_read.json_reader
 is_avro = _read.is_avro
-LOGICAL_READERS = _read.LOGICAL_READERS
+LOGICAL_READERS = logical_readers.LOGICAL_READERS
 SchemaResolutionError = _read_common.SchemaResolutionError
 
 __all__ = [

--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,7 @@ if not hasattr(sys, "pypy_version_info"):
         Extension("fastavro._schema", ["fastavro/_schema" + ext]),
         Extension("fastavro._write", ["fastavro/_write" + ext]),
         Extension("fastavro._validation", ["fastavro/_validation" + ext]),
+        Extension("fastavro._logical_readers", ["fastavro/_logical_readers" + ext]),
         Extension("fastavro._logical_writers", ["fastavro/_logical_writers" + ext]),
     ]
 

--- a/tests/test_logical_types.py
+++ b/tests/test_logical_types.py
@@ -1,3 +1,5 @@
+import io
+
 import fastavro
 from fastavro.__main__ import CleanJSONEncoder
 import json
@@ -546,3 +548,26 @@ def test_ndarray_union():
     binary = serialize(schema, two_d)
     data2 = deserialize(schema, binary)
     np.testing.assert_equal(two_d, data2)
+
+
+def test_custom_logical_type_json_reader():
+    def decode_custom_json(data, *args, **kwargs):
+        return json.loads(data)
+
+    custom_schema = {
+        "name": "Issue",
+        "type": "record",
+        "fields": [
+            {"name": "issue_json", "default": None, "type": {"type": "string", "logicalType": "custom-json"}},
+        ],
+    }
+
+    fastavro.read.LOGICAL_READERS["string-custom-json"] = decode_custom_json
+
+    custom_json_object = {
+        "issue_json": "{\"key\": \"value\"}",
+    }
+
+    object_bytes = io.BytesIO(json.dumps(custom_json_object).encode())
+    re1 = fastavro.json_reader(fo=object_bytes, schema=custom_schema)
+    assert next(re1) == {"issue_json": {"key": "value"}}


### PR DESCRIPTION
- Fixes issue #597 
- LOGICAL READERS reference wouldn't work for `json_readers` for custom logical types 
- This PR uses the same approach of `logical_writers` for the `logical_readers`