### PR TITLE
Raise EOFError for truncated bytes and fixed data (and transitively strings)

### DIFF
--- a/fastavro/_read_py.py
+++ b/fastavro/_read_py.py
@@ -945,7 +945,7 @@ class file_reader(Generic[T]):
                 self.return_record_name,
                 self.return_record_name_override,
             )
-        except StopIteration:
+        except (StopIteration, EOFError):
             raise ValueError("cannot read header - is it an avro file?")
 
         # `meta` values are bytes. So, the actual decoding has to be external.

--- a/fastavro/io/binary_decoder.py
+++ b/fastavro/io/binary_decoder.py
@@ -73,7 +73,7 @@ class BinaryDecoder:
         size = self.read_long()
         out = self.fo.read(size)
         if len(out) != size:
-            raise ValueError
+            raise EOFError(f"Expected {size} bytes, read {len(out)}")
         return out
 
     def read_utf8(self):
@@ -87,7 +87,7 @@ class BinaryDecoder:
         schema."""
         out = self.fo.read(size)
         if len(out) < size:
-            raise ValueError
+            raise EOFError(f"Expected {size} bytes, read {len(out)}")
         return out
 
     def read_enum(self):

--- a/fastavro/io/binary_decoder.py
+++ b/fastavro/io/binary_decoder.py
@@ -71,7 +71,10 @@ class BinaryDecoder:
     def read_bytes(self):
         """Bytes are encoded as a long followed by that many bytes of data."""
         size = self.read_long()
-        return self.fo.read(size)
+        out = self.fo.read(size)
+        if len(out) < size:
+            raise ValueError
+        return out
 
     def read_utf8(self):
         """A string is encoded as a long followed by that many bytes of UTF-8
@@ -82,7 +85,10 @@ class BinaryDecoder:
     def read_fixed(self, size):
         """Fixed instances are encoded using the number of bytes declared in the
         schema."""
-        return self.fo.read(size)
+        out = self.fo.read(size)
+        if len(out) < size:
+            raise ValueError
+        return out
 
     def read_enum(self):
         """An enum is encoded by a int, representing the zero-based position of the

--- a/fastavro/io/binary_decoder.py
+++ b/fastavro/io/binary_decoder.py
@@ -72,7 +72,7 @@ class BinaryDecoder:
         """Bytes are encoded as a long followed by that many bytes of data."""
         size = self.read_long()
         out = self.fo.read(size)
-        if len(out) < size:
+        if len(out) != size:
             raise ValueError
         return out
 

--- a/tests/test_fastavro.py
+++ b/tests/test_fastavro.py
@@ -1297,6 +1297,44 @@ def test_eof_error():
     with pytest.raises(EOFError):
         fastavro.schemaless_reader(new_file, schema)
 
+def test_eof_error_string():
+    schema = "string"
+    new_file = BytesIO()
+    fastavro.schemaless_writer(new_file, schema, "1234567890")
+
+    # Back up one byte and truncate
+    new_file.seek(-1, 1)
+    new_file.truncate()
+
+    new_file.seek(0)
+    with pytest.raises(EOFError):
+        fastavro.schemaless_reader(new_file, schema)
+
+def test_eof_error_fixed():
+    schema = {"type": "fixed", "size": 10, "name": "test"} 
+    new_file = BytesIO()
+    fastavro.schemaless_writer(new_file, schema, b"1234567890")
+
+    # Back up one byte and truncate
+    new_file.seek(-1, 1)
+    new_file.truncate()
+
+    new_file.seek(0)
+    with pytest.raises(EOFError):
+        fastavro.schemaless_reader(new_file, schema)
+
+def test_eof_error_bytes():
+    schema = "bytes"
+    new_file = BytesIO()
+    fastavro.schemaless_writer(new_file, schema, b"1234567890")
+
+    # Back up one byte and truncate
+    new_file.seek(-1, 1)
+    new_file.truncate()
+
+    new_file.seek(0)
+    with pytest.raises(EOFError):
+        fastavro.schemaless_reader(new_file, schema)
 
 def test_write_union_tuple_uses_namespaced_name():
     """

--- a/tests/test_fastavro.py
+++ b/tests/test_fastavro.py
@@ -1297,6 +1297,7 @@ def test_eof_error():
     with pytest.raises(EOFError):
         fastavro.schemaless_reader(new_file, schema)
 
+
 def test_eof_error_string():
     schema = "string"
     new_file = BytesIO()
@@ -1310,8 +1311,9 @@ def test_eof_error_string():
     with pytest.raises(EOFError):
         fastavro.schemaless_reader(new_file, schema)
 
+
 def test_eof_error_fixed():
-    schema = {"type": "fixed", "size": 10, "name": "test"} 
+    schema = {"type": "fixed", "size": 10, "name": "test"}
     new_file = BytesIO()
     fastavro.schemaless_writer(new_file, schema, b"1234567890")
 
@@ -1322,6 +1324,7 @@ def test_eof_error_fixed():
     new_file.seek(0)
     with pytest.raises(EOFError):
         fastavro.schemaless_reader(new_file, schema)
+
 
 def test_eof_error_bytes():
     schema = "bytes"
@@ -1335,6 +1338,7 @@ def test_eof_error_bytes():
     new_file.seek(0)
     with pytest.raises(EOFError):
         fastavro.schemaless_reader(new_file, schema)
+
 
 def test_write_union_tuple_uses_namespaced_name():
     """


### PR DESCRIPTION
If an incomplete Avro byte sequence is provided for certain types, namely `bytes`, `string` and `fixed`, 
fastavro will return the truncated version rather than erroring indicating the failure.

This is a problem if for instance the Avro bytes are being transmitted over a network that may have momentary lag that provides incomplete records and requires retrying parsing once additional data is available.

Specifically:

```python
>>> from io import BytesIO
>>> file = BytesIO(b"\x0a123")
>>> fastavro.schemaless_reader(file, "string")
```

This represents a string which claims to be 5 bytes long (0x0a in avro's integer format), but only provides 3 bytes.
Existing fastavro will return `"123"`, leaving bytes still in transit out.

Apache's reference python implementation does have a custom exception that is raised in this instance.

- tests for truncated strings, bytes, fixed
- Raise EOFError for truncated bytes and fixed data (and transitively strings)
