### PR TITLE
Improve error messages

### DIFF
--- a/fastavro/_read.pyx
+++ b/fastavro/_read.pyx
@@ -322,7 +322,7 @@ cpdef read_enum(fo, writer_schema, reader_schema):
             return default
         else:
             symlist = reader_schema["symbols"]
-            msg = f"{symbol} not found in reader symbol list {symlist}"
+            msg = f"{symbol} not found in reader symbol list {reader_schema['name']}, known symbols: {repr(symlist)}"
             raise SchemaResolutionError(msg)
     return symbol
 
@@ -658,7 +658,7 @@ cpdef read_record(
                     if "default" in field:
                         record[field["name"]] = field["default"]
                     else:
-                        msg = f"No default value for {field['name']}"
+                        msg = f"No default value for field {field['name']} in {reader_schema['name']}"
                         raise SchemaResolutionError(msg)
 
     return record

--- a/tests/test_schema_evolution.py
+++ b/tests/test_schema_evolution.py
@@ -1,3 +1,5 @@
+import re
+
 from fastavro import writer as fastavro_writer
 from fastavro.read import SchemaResolutionError
 from fastavro.utils import generate_one
@@ -62,7 +64,10 @@ def test_evolution_add_field_with_default():
 
 
 def test_evolution_add_field_without_default():
-    with pytest.raises(SchemaResolutionError):
+    with pytest.raises(
+        SchemaResolutionError,
+        match="No default value for field c in example.avro2.evtest",
+    ):
         record_bytes_a = avro_to_bytes_with_schema(schema_dict_a, record_a)
         bytes_with_schema_to_avro(schema_dict_a_c, record_bytes_a)
 
@@ -86,7 +91,12 @@ def test_enum_evolution_no_default_failure():
     fastavro.writer(bio, original_schema, original_records)
     bio.seek(0)
 
-    with pytest.raises(fastavro.read.SchemaResolutionError):
+    with pytest.raises(
+        fastavro.read.SchemaResolutionError,
+        match=re.escape(
+            "FOO not found in reader symbol list test, known symbols: ['BAZ', 'BAR']"
+        ),
+    ):
         list(fastavro.reader(bio, new_schema))
 
 
@@ -703,7 +713,12 @@ def test_writer_enum_more_symbols_than_reader_enum():
         if symbol in reader_schema["symbols"]:
             list(fastavro.reader(bio, reader_schema))
         else:
-            with pytest.raises(SchemaResolutionError):
+            with pytest.raises(
+                SchemaResolutionError,
+                match=re.escape(
+                    "C not found in reader symbol list enum, known symbols: ['A', 'B']"
+                ),
+            ):
                 list(fastavro.reader(bio, reader_schema))
 
 


### PR DESCRIPTION
Better error messages when an enum contains an unknown item or when reader schema doesn't have a default set for a missing value.

**Before**

```
fastavro._read_common.SchemaResolutionError: CLUBS not found in reader symbol list ['SPADES', 'HEARTS', 'DIAMONDS']
```

**After**
```
fastavro._read_common.SchemaResolutionError: CLUBS not found in reader symbol list test.Suit, known symbols: ['SPADES', 'HEARTS', 'DIAMONDS']
```

@scottbelden the new error messages are just an suggestion, they can be formatted differently. 


What do you think?
