### PR TITLE
Update enum symbol validation to enforce avro spec on the entire symbol

### DIFF
--- a/fastavro/_schema.pyx
+++ b/fastavro/_schema.pyx
@@ -756,7 +756,7 @@ def fingerprint(parsing_canonical_form, algorithm):
 def _validate_enum_symbols(schema):
     symbols = schema["symbols"]
     for symbol in symbols:
-        if not isinstance(symbol, str) or not re.match(SYMBOL_REGEX, symbol):
+        if not isinstance(symbol, str) or not SYMBOL_REGEX.fullmatch(symbol):
             raise SchemaParseException(
                 "Every symbol must match the regular expression [A-Za-z_][A-Za-z0-9_]*"
             )

--- a/fastavro/_schema_py.py
+++ b/fastavro/_schema_py.py
@@ -1035,7 +1035,7 @@ def fingerprint(parsing_canonical_form: str, algorithm: str) -> str:
 def _validate_enum_symbols(schema):
     symbols = schema["symbols"]
     for symbol in symbols:
-        if not isinstance(symbol, str) or not re.match(SYMBOL_REGEX, symbol):
+        if not isinstance(symbol, str) or not SYMBOL_REGEX.fullmatch(symbol):
             raise SchemaParseException(
                 "Every symbol must match the regular expression [A-Za-z_][A-Za-z0-9_]*"
             )

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -1110,7 +1110,7 @@ def test_explicit_null_namespace_2():
     assert parsed_schema["name"] == "my_schema"
 
 
-@pytest.mark.parametrize("symbol", [None, 0, "Ż", "0nope"])
+@pytest.mark.parametrize("symbol", [None, 0, "Ż", "0nope", "string with spaces"])
 def test_enum_symbols_validation__invalid(symbol):
     """https://github.com/fastavro/fastavro/issues/551"""
     invalid_schema = {


### PR DESCRIPTION
Resolves #727.

`re.match` would return a match if the beginning of the string matched the regex pattern. This allowed ill-formed symbols to pass validation if the beginning of the string complied with the Avro spec. `re.fullmatch` only returns a match if the entire string matches the regex pattern, which yields behavior in line with the Avro spec.

Additionally, note that invoking the `fullmatch` method from a compiled pattern runs approximately 3.6x faster than invoking `fullmatch` from the `re` package and passing the compiled pattern as a parameter. This is likely negligible in the grand scheme of things, but we might as well opt for the faster approach.

Simple benchmark script used to ascertain those results:
```python
import re
import timeit

if __name__ == '__main__':
    symbol = re.compile(r"[A-Za-z_][A-Za-z0-9_]*")
    s = 'string with spaces'

    def test_re():
        return re.fullmatch(symbol, s)

    def test_symbol():
        return symbol.fullmatch(s)

    assert test_re() == test_symbol()

    R = 50
    r = timeit.repeat(stmt='test_re()', repeat=R, globals=globals())
    print(f're.fullmatch: {min(r)}')

    r = timeit.repeat(stmt='test_symbol()', repeat=R, globals=globals())
    print(f'symbol.fullmatch: {min(r)}')

```
which produced:
```
re.fullmatch: 0.4571467499999926
symbol.fullmatch: 0.1259777919995031
```