### PR TITLE
Don't run `python .../fastavro/__main__.py` in tests

### DIFF
--- a/tests/test_main_cli.py
+++ b/tests/test_main_cli.py
@@ -8,15 +8,11 @@ import subprocess
 
 data_dir = os.path.join(os.path.abspath(os.path.dirname(__file__)), "avro-files")
 
-main_py = os.path.join(
-    os.path.abspath(os.path.dirname(__file__)), os.pardir, "fastavro", "__main__.py"
-)
-
 
 def test_cli_record_output():
     # given,
     given_avro_input = os.path.join(data_dir, "weather.avro")
-    given_cmd_args = [sys.executable, main_py, given_avro_input]
+    given_cmd_args = [sys.executable, "-m", "fastavro", given_avro_input]
     expected_data = [
         {"station": "011990-99999", "time": -619524000000, "temp": 0},
         {"station": "011990-99999", "time": -619506000000, "temp": 22},
@@ -37,7 +33,7 @@ def test_cli_stream_input():
     # given,
     given_avro_input = os.path.join(data_dir, "weather.avro")
     given_stdin_stream = open(given_avro_input, "rb")
-    given_cmd_args = [sys.executable, main_py, "-"]
+    given_cmd_args = [sys.executable, "-m", "fastavro", "-"]
     expected_data = [
         {"station": "011990-99999", "time": -619524000000, "temp": 0},
         {"station": "011990-99999", "time": -619506000000, "temp": 22},
@@ -61,7 +57,7 @@ def test_cli_stream_input():
 def test_cli_arg_metadata():
     # given,
     given_avro_input = os.path.join(data_dir, "testDataFileMeta.avro")
-    given_cmd_args = [sys.executable, main_py, "--metadata", given_avro_input]
+    given_cmd_args = [sys.executable, "-m", "fastavro", "--metadata", given_avro_input]
     expected_metadata = {"hello": "bar"}
 
     # exercise,
@@ -75,7 +71,7 @@ def test_cli_arg_metadata():
 def test_cli_arg_schema():
     # given,
     given_avro_input = os.path.join(data_dir, "weather.avro")
-    given_cmd_args = [sys.executable, main_py, "--schema", given_avro_input]
+    given_cmd_args = [sys.executable, "-m", "fastavro", "--schema", given_avro_input]
     expected_schema = {
         "type": "record",
         "name": "Weather",
@@ -98,7 +94,7 @@ def test_cli_arg_schema():
 
 def test_cli_arg_codecs():
     # given,
-    given_cmd_args = [sys.executable, main_py, "--codecs"]
+    given_cmd_args = [sys.executable, "-m", "fastavro", "--codecs"]
     default_codecs = ("deflate", "null")
 
     # exercise,


### PR DESCRIPTION
The __main__.py file is executed via `python -m fastavro`.

Users don't execute `__main__.py` directly anyway.

When the file is executed by its path,
the directory containing it is prepended to sys.path by default (unless $PYTHONSAFEPATH is set or `python -P` is used).

When the fastavro directory is first sys.path,
`import types` imports fastvaro/types.py
rather than the standard library types module.

This leads to problems:

    Traceback (most recent call last):
      File ".../fastavro/fastavro/__main__.py", line 3, in <module>
        import json
      File "/usr/lib64/python3.12/json/__init__.py", line 106, in <module>
        from .decoder import JSONDecoder, JSONDecodeError
      File "/usr/lib64/python3.12/json/decoder.py", line 3, in <module>
        import re
      File "/usr/lib64/python3.12/re/__init__.py", line 124, in <module>
        import enum
      File "/usr/lib64/python3.12/enum.py", line 3, in <module>
        from types import MappingProxyType, DynamicClassAttribute
      File ".../fastavro/fastavro/types.py", line 2, in <module>
        from typing import Union, List, Dict
      File "/usr/lib64/python3.12/typing.py", line 27, in <module>
        import contextlib
      File "/usr/lib64/python3.12/contextlib.py", line 7, in <module>
        from functools import wraps
      File "/usr/lib64/python3.12/functools.py", line 22, in <module>
        from types import GenericAlias
    ImportError: cannot import name 'GenericAlias' from partially initialized module 'types' (most likely due to a circular import) (.../fastavro/fastavro/types.py)

This only happens to work accidentally
when the tests are executed on editable installation of fastavro.

The `.tox/py312/lib64/python3.12/site-packages/__editable__.fastavro-1.9.0.pth` file triggers an early import of the types module *before* the parent directory of ` __main__` is added to sys.path. A subsequent import of types then work because it reuses `sys.modules["types"]`.

However, when the tests are executed from an environment without such .pth file, they explode this way.

We have discovered this in Fedora, where we run the tests slightly differently.

When we had `sphinxcontrib_jsmath-1.0.1-py3.12-nspkg.pth` installed, the tests passed. When we removed it, they exploded.