### PR TITLE
Allow arbitrary ordering of union fields

### DIFF
--- a/fastavro/_schema.pyx
+++ b/fastavro/_schema.pyx
@@ -183,11 +183,11 @@ def parse_schema(
 
 
 cdef _raise_default_value_error(
-    default, schema_type, in_union, ignore_default_error
+    default, schema_type, ignore_default_error
 ):
     if ignore_default_error:
         return
-    elif in_union:
+    elif isinstance(schema_type, list):
         text = f"a schema in union with type: {schema_type}"
     else:
         text = f"schema type: {schema_type}"
@@ -226,7 +226,6 @@ cdef _parse_schema(
     named_schemas,
     default,
     ignore_default_error,
-    in_union=False,
 ):
     # union schemas
     if isinstance(schema, list):
@@ -248,7 +247,7 @@ cdef _parse_schema(
                 if _default_matches_schema(default, s):
                     break
             else:
-                _raise_default_value_error(default, schema, True, ignore_default_error)
+                _raise_default_value_error(default, schema, ignore_default_error)
         return parsed_schemas
 
     # string schemas; this could be either a named schema or a primitive type
@@ -257,7 +256,7 @@ cdef _parse_schema(
             if default is not NO_DEFAULT:
                 if not _default_matches_schema(default, schema):
                     _raise_default_value_error(
-                        default, schema, in_union, ignore_default_error
+                        default, schema, ignore_default_error
                     )
             return schema
 
@@ -338,7 +337,7 @@ cdef _parse_schema(
             )
             if default is not NO_DEFAULT and not isinstance(default, list):
                 _raise_default_value_error(
-                    default, schema_type, in_union, ignore_default_error
+                    default, schema_type, ignore_default_error
                 )
 
         elif schema_type == "map":
@@ -354,7 +353,7 @@ cdef _parse_schema(
             )
             if default is not NO_DEFAULT and not isinstance(default, dict):
                 _raise_default_value_error(
-                    default, schema_type, in_union, ignore_default_error
+                    default, schema_type, ignore_default_error
                 )
 
         elif schema_type == "enum":
@@ -367,7 +366,7 @@ cdef _parse_schema(
 
             if default is not NO_DEFAULT and not isinstance(default, str):
                 _raise_default_value_error(
-                    default, schema_type, in_union, ignore_default_error
+                    default, schema_type, ignore_default_error
                 )
 
             named_schemas[fullname] = parsed_schema
@@ -383,7 +382,7 @@ cdef _parse_schema(
 
             if default is not NO_DEFAULT and not isinstance(default, str):
                 _raise_default_value_error(
-                    default, schema_type, in_union, ignore_default_error
+                    default, schema_type, ignore_default_error
                 )
 
             named_schemas[fullname] = parsed_schema
@@ -400,7 +399,7 @@ cdef _parse_schema(
 
             if default is not NO_DEFAULT and not isinstance(default, dict):
                 _raise_default_value_error(
-                    default, schema_type, in_union, ignore_default_error
+                    default, schema_type, ignore_default_error
                 )
 
             named_schemas[fullname] = parsed_schema
@@ -447,7 +446,7 @@ cdef _parse_schema(
                     or (schema_type == "long" and not isinstance(default, int))
                 ):
                     _raise_default_value_error(
-                        default, schema_type, in_union, ignore_default_error
+                        default, schema_type, ignore_default_error
                     )
 
         else:

--- a/fastavro/_schema.pyx
+++ b/fastavro/_schema.pyx
@@ -188,11 +188,33 @@ cdef _raise_default_value_error(
     if ignore_default_error:
         return
     elif in_union:
-        text = f"first schema in union with type: {schema_type}"
+        text = f"a schema in union with type: {schema_type}"
     else:
         text = f"schema type: {schema_type}"
 
     raise SchemaParseException(f"Default value <{default}> must match {text}")
+
+
+cdef _maybe_float(value):
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return value
+
+
+cdef _default_matches_schema(default, schema):
+    if (
+        (schema == "null" and default is not None)
+        or (schema == "boolean" and not isinstance(default, bool))
+        or (schema == "string" and not isinstance(default, str))
+        or (schema == "bytes" and not isinstance(default, str))
+        or (schema == "double" and not isinstance(_maybe_float(default), float))
+        or (schema == "float" and not isinstance(_maybe_float(default), float))
+        or (schema == "int" and not isinstance(default, int))
+        or (schema == "long" and not isinstance(default, int))
+    ):
+        return False
+    return True
 
 
 cdef _parse_schema(
@@ -208,51 +230,32 @@ cdef _parse_schema(
 ):
     # union schemas
     if isinstance(schema, list):
-        parsed_schemas = []
-        for index, s in enumerate(schema):
-            if index == 0:
-                parsed_schemas.append(
-                    _parse_schema(
-                        s,
-                        namespace,
-                        expand,
-                        False,
-                        names,
-                        named_schemas,
-                        default,
-                        ignore_default_error,
-                        in_union=True,
-                    )
-                )
+        parsed_schemas = [
+            _parse_schema(
+                s,
+                namespace,
+                expand,
+                False,
+                names,
+                named_schemas,
+                NO_DEFAULT,
+                ignore_default_error,
+            )
+            for s in schema
+        ]
+        if default is not NO_DEFAULT:
+            for s in parsed_schemas:
+                if _default_matches_schema(default, s):
+                    break
             else:
-                parsed_schemas.append(
-                    _parse_schema(
-                        s,
-                        namespace,
-                        expand,
-                        False,
-                        names,
-                        named_schemas,
-                        NO_DEFAULT,
-                        ignore_default_error,
-                    )
-                )
+                _raise_default_value_error(default, schema, True, ignore_default_error)
         return parsed_schemas
 
     # string schemas; this could be either a named schema or a primitive type
     elif not isinstance(schema, dict):
         if schema in PRIMITIVES:
             if default is not NO_DEFAULT:
-                if (
-                    (schema == "null" and default is not None)
-                    or (schema == "boolean" and not isinstance(default, bool))
-                    or (schema == "string" and not isinstance(default, str))
-                    or (schema == "bytes" and not isinstance(default, str))
-                    or (schema == "double" and not isinstance(float(default), float))
-                    or (schema == "float" and not isinstance(float(default), float))
-                    or (schema == "int" and not isinstance(default, int))
-                    or (schema == "long" and not isinstance(default, int))
-                ):
+                if not _default_matches_schema(default, schema):
                     _raise_default_value_error(
                         default, schema, in_union, ignore_default_error
                     )

--- a/fastavro/_schema_py.py
+++ b/fastavro/_schema_py.py
@@ -322,11 +322,11 @@ def parse_schema(
 
 
 def _raise_default_value_error(
-    default: Any, schema_type: Any, in_union: bool, ignore_default_error: bool
+    default: Any, schema_type: Any, ignore_default_error: bool
 ):
     if ignore_default_error:
         return
-    elif in_union:
+    elif isinstance(schema_type, list):
         text = f"a schema in union with type: {schema_type}"
     else:
         text = f"schema type: {schema_type}"
@@ -366,8 +366,6 @@ def _parse_schema(
     named_schemas: NamedSchemas,
     default: Any,
     ignore_default_error: bool,
-    *,
-    in_union: bool = False,
 ) -> Schema:
     # union schemas
     if isinstance(schema, list):
@@ -389,7 +387,7 @@ def _parse_schema(
                 if _default_matches_schema(default, s):
                     break
             else:
-                _raise_default_value_error(default, schema, True, ignore_default_error)
+                _raise_default_value_error(default, schema, ignore_default_error)
         return parsed_schemas
 
     # string schemas; this could be either a named schema or a primitive type
@@ -397,9 +395,7 @@ def _parse_schema(
         if schema in PRIMITIVES:
             if default is not NO_DEFAULT:
                 if not _default_matches_schema(default, schema):
-                    _raise_default_value_error(
-                        default, schema, in_union, ignore_default_error
-                    )
+                    _raise_default_value_error(default, schema, ignore_default_error)
             return schema
 
         if "." not in schema and namespace:
@@ -478,9 +474,7 @@ def _parse_schema(
                 ignore_default_error,
             )
             if default is not NO_DEFAULT and not isinstance(default, list):
-                _raise_default_value_error(
-                    default, schema_type, in_union, ignore_default_error
-                )
+                _raise_default_value_error(default, schema_type, ignore_default_error)
 
         elif schema_type == "map":
             parsed_schema["values"] = _parse_schema(
@@ -494,9 +488,7 @@ def _parse_schema(
                 ignore_default_error,
             )
             if default is not NO_DEFAULT and not isinstance(default, dict):
-                _raise_default_value_error(
-                    default, schema_type, in_union, ignore_default_error
-                )
+                _raise_default_value_error(default, schema_type, ignore_default_error)
 
         elif schema_type == "enum":
             _, fullname = schema_name(schema, namespace)
@@ -507,9 +499,7 @@ def _parse_schema(
             _validate_enum_symbols(schema)
 
             if default is not NO_DEFAULT and not isinstance(default, str):
-                _raise_default_value_error(
-                    default, schema_type, in_union, ignore_default_error
-                )
+                _raise_default_value_error(default, schema_type, ignore_default_error)
 
             named_schemas[fullname] = parsed_schema
 
@@ -523,9 +513,7 @@ def _parse_schema(
             names.add(fullname)
 
             if default is not NO_DEFAULT and not isinstance(default, str):
-                _raise_default_value_error(
-                    default, schema_type, in_union, ignore_default_error
-                )
+                _raise_default_value_error(default, schema_type, ignore_default_error)
 
             named_schemas[fullname] = parsed_schema
 
@@ -540,9 +528,7 @@ def _parse_schema(
             names.add(fullname)
 
             if default is not NO_DEFAULT and not isinstance(default, dict):
-                _raise_default_value_error(
-                    default, schema_type, in_union, ignore_default_error
-                )
+                _raise_default_value_error(default, schema_type, ignore_default_error)
 
             named_schemas[fullname] = parsed_schema
 
@@ -586,7 +572,7 @@ def _parse_schema(
                     or (schema_type == "long" and not isinstance(default, int))
                 ):
                     _raise_default_value_error(
-                        default, schema_type, in_union, ignore_default_error
+                        default, schema_type, ignore_default_error
                     )
 
         else:

--- a/fastavro/_schema_py.py
+++ b/fastavro/_schema_py.py
@@ -322,16 +322,39 @@ def parse_schema(
 
 
 def _raise_default_value_error(
-    default: Any, schema_type: str, in_union: bool, ignore_default_error: bool
+    default: Any, schema_type: Any, in_union: bool, ignore_default_error: bool
 ):
     if ignore_default_error:
         return
     elif in_union:
-        text = f"first schema in union with type: {schema_type}"
+        text = f"a schema in union with type: {schema_type}"
     else:
         text = f"schema type: {schema_type}"
 
     raise SchemaParseException(f"Default value <{default}> must match {text}")
+
+
+def _maybe_float(value: Any) -> Any:
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return value
+
+
+def _default_matches_schema(default: Any, schema: Schema) -> bool:
+    # TODO: Consider using the validate functions here
+    if (
+        (schema == "null" and default is not None)
+        or (schema == "boolean" and not isinstance(default, bool))
+        or (schema == "string" and not isinstance(default, str))
+        or (schema == "bytes" and not isinstance(default, str))
+        or (schema == "double" and not isinstance(_maybe_float(default), float))
+        or (schema == "float" and not isinstance(_maybe_float(default), float))
+        or (schema == "int" and not isinstance(default, int))
+        or (schema == "long" and not isinstance(default, int))
+    ):
+        return False
+    return True
 
 
 def _parse_schema(
@@ -348,52 +371,32 @@ def _parse_schema(
 ) -> Schema:
     # union schemas
     if isinstance(schema, list):
-        parsed_schemas = []
-        for index, s in enumerate(schema):
-            if index == 0:
-                parsed_schemas.append(
-                    _parse_schema(
-                        s,
-                        namespace,
-                        expand,
-                        False,
-                        names,
-                        named_schemas,
-                        default,
-                        ignore_default_error,
-                        in_union=True,
-                    )
-                )
+        parsed_schemas = [
+            _parse_schema(
+                s,
+                namespace,
+                expand,
+                False,
+                names,
+                named_schemas,
+                NO_DEFAULT,
+                ignore_default_error,
+            )
+            for s in schema
+        ]
+        if default is not NO_DEFAULT:
+            for s in parsed_schemas:
+                if _default_matches_schema(default, s):
+                    break
             else:
-                parsed_schemas.append(
-                    _parse_schema(
-                        s,
-                        namespace,
-                        expand,
-                        False,
-                        names,
-                        named_schemas,
-                        NO_DEFAULT,
-                        ignore_default_error,
-                    )
-                )
+                _raise_default_value_error(default, schema, True, ignore_default_error)
         return parsed_schemas
 
     # string schemas; this could be either a named schema or a primitive type
     elif not isinstance(schema, dict):
         if schema in PRIMITIVES:
             if default is not NO_DEFAULT:
-                # TODO: Consider using the validate functions here
-                if (
-                    (schema == "null" and default is not None)
-                    or (schema == "boolean" and not isinstance(default, bool))
-                    or (schema == "string" and not isinstance(default, str))
-                    or (schema == "bytes" and not isinstance(default, str))
-                    or (schema == "double" and not isinstance(float(default), float))
-                    or (schema == "float" and not isinstance(float(default), float))
-                    or (schema == "int" and not isinstance(default, int))
-                    or (schema == "long" and not isinstance(default, int))
-                ):
+                if not _default_matches_schema(default, schema):
                     _raise_default_value_error(
                         default, schema, in_union, ignore_default_error
                     )


### PR DESCRIPTION
Since the Java reference implementation no longer enforces the requirement that the default value be the first type in a union, drop this requirement from fastavro as well.  This restores the ability to read data written with fastavro <1.7, while still checking that the default is (or is convertible to) one of the union types. Along the way, refactor the special cases for double and float so that they do not raise exceptions.

Fixes #723