### PR TITLE
style: simplify condition in _parse_schema method

### DIFF
--- a/fastavro/_schema.pyx
+++ b/fastavro/_schema.pyx
@@ -72,7 +72,7 @@ cpdef inline extract_record_type(schema):
     if isinstance(schema, list):
         return "union"
 
-    return schema  
+    return schema
 
 
 cpdef inline str extract_logical_type(schema):
@@ -265,18 +265,15 @@ cdef _parse_schema(
 
         if schema not in named_schemas:
             raise UnknownType(schema)
-        elif expand:
+
+        if expand and "name" in named_schemas[schema]:
             # If `name` is in the schema, it has been fully resolved and so we
             # can include the full schema. If `name` is not in the schema yet,
             # then we are still recursing that schema and must use the named
             # schema or else we will have infinite recursion when printing the
             # final schema
-            if "name" in named_schemas[schema]:
-                return named_schemas[schema]
-            else:
-                return schema
-        else:
-            return schema
+            return named_schemas[schema]
+        return schema
 
     else:
         # Remaining valid schemas must be dict types

--- a/fastavro/_schema_py.py
+++ b/fastavro/_schema_py.py
@@ -403,18 +403,15 @@ def _parse_schema(
 
         if schema not in named_schemas:
             raise UnknownType(schema)
-        elif expand:
+
+        if expand and "name" in named_schemas[schema]:
             # If `name` is in the schema, it has been fully resolved and so we
             # can include the full schema. If `name` is not in the schema yet,
             # then we are still recursing that schema and must use the named
             # schema or else we will have infinite recursion when printing the
             # final schema
-            if "name" in named_schemas[schema]:
-                return named_schemas[schema]
-            else:
-                return schema
-        else:
-            return schema
+            return named_schemas[schema]
+        return schema
 
     else:
         # Remaining valid schemas must be dict types


### PR DESCRIPTION
Hey,

I was working on fixing [python-schema-registry-client](https://github.com/marcosschroh/python-schema-registry-client) bump to fastavro 1.9.3 and due typing issue I end up here reading the code source, I found the following code block can be simplified.

Code behavior should not change via this PR.

_I read the Contributing part and I think this change could go straight to a PR. If you mind differently don't hesitate to tell me_