### PR TITLE
fix return_record_name option for aliases in a union

### DIFF
--- a/fastavro/_read_py.py
+++ b/fastavro/_read_py.py
@@ -400,6 +400,7 @@ def read_union(
     # schema resolution
     index = decoder.read_index()
     idx_schema = writer_schema[index]
+    idx_reader_schema = None
 
     if reader_schema:
         msg = f"schema mismatch: {writer_schema} not found in {reader_schema}"
@@ -418,6 +419,7 @@ def read_union(
         else:
             for schema in reader_schema:
                 if match_types(idx_schema, schema, named_schemas):
+                    idx_reader_schema = schema
                     result = read_data(
                         decoder,
                         idx_schema,
@@ -438,17 +440,33 @@ def read_union(
     if return_named_type_override and is_single_name_union(writer_schema):
         return result
     elif return_named_type and extract_record_type(idx_schema) in NAMED_TYPES:
-        return (idx_schema["name"], result)
+        schema_name = (
+            idx_reader_schema["name"] if idx_reader_schema else idx_schema["name"]
+        )
+        return (schema_name, result)
     elif return_named_type and extract_record_type(idx_schema) not in AVRO_TYPES:
         # idx_schema is a named type
-        return (named_schemas["writer"][idx_schema]["name"], result)
+        schema_name = (
+            named_schemas["reader"][idx_reader_schema]["name"]
+            if idx_reader_schema
+            else named_schemas["writer"][idx_schema]["name"]
+        )
+        return (schema_name, result)
     elif return_record_name_override and is_single_record_union(writer_schema):
         return result
     elif return_record_name and extract_record_type(idx_schema) == "record":
-        return (idx_schema["name"], result)
+        schema_name = (
+            idx_reader_schema["name"] if idx_reader_schema else idx_schema["name"]
+        )
+        return (schema_name, result)
     elif return_record_name and extract_record_type(idx_schema) not in AVRO_TYPES:
         # idx_schema is a named type
-        return (named_schemas["writer"][idx_schema]["name"], result)
+        schema_name = (
+            named_schemas["reader"][idx_reader_schema]["name"]
+            if idx_reader_schema
+            else named_schemas["writer"][idx_schema]["name"]
+        )
+        return (schema_name, result)
     else:
         return result
 


### PR DESCRIPTION
These changes should fix a issue with the `return_record_name` and `return_named_type` reader options that occur during schema resolution in a union with aliases.

The issue is that if:

- `return_record_name` is set to True
- or `return_named_type` is set to True

one would expect that the returned names are the names from the reader schema. But this is currently not the case when:

- the writer schema has a union where one of the branches is a named record
- the reader schema changes the name of that record and also adds a alias for the old name

**Then the record name of writer schema is returned**. 

This causes some issues like:

- no being able to re-encode the message with the reader schema (the reader schema has no record with the old name)
- having to check the old and new name in code