### PR TITLE
Resolve referenced schema to disambiguate union types with named schemas

### DIFF
--- a/fastavro/_write.pyx
+++ b/fastavro/_write.pyx
@@ -308,6 +308,12 @@ cdef write_union(bytearray fo, datum, schema, dict named_schemas, fname, dict op
                 options=options,
             ):
                 record_type = extract_record_type(candidate)
+
+                if record_type in named_schemas:
+                    # Convert named record types into their full schema so that we can check most_fields
+                    candidate = named_schemas[record_type]
+                    record_type = "record"
+
                 if record_type == "record":
                     logical_type = extract_logical_type(candidate)
                     if logical_type:

--- a/fastavro/_write_py.py
+++ b/fastavro/_write_py.py
@@ -193,6 +193,11 @@ def write_union(encoder, datum, schema, named_schemas, fname, options):
                 options=options,
             ):
                 record_type = extract_record_type(candidate)
+                if record_type in named_schemas:
+                    # Convert named record types into their full schema so that we can check most_fields
+                    candidate = named_schemas[record_type]
+                    record_type = "record"
+
                 if record_type == "record":
                     logical_type = extract_logical_type(candidate)
                     if logical_type:

--- a/tests/test_fastavro.py
+++ b/tests/test_fastavro.py
@@ -1986,6 +1986,48 @@ def test_logical_type_in_union():
     assert expected == roundtrip(schema, records)
 
 
+def test_named_schema_disambiguation_in_union():
+    schema = [
+        {
+            "name": "one_named_type",
+            "namespace": "com.example",
+            "type": "record",
+            "fields": [{"name": "field_one", "type": "int"}],
+        },
+        {
+            "name": "two_named_type",
+            "namespace": "com.example",
+            "type": "record",
+            "fields": [
+                {"name": "field_one", "type": "int"},
+                {"name": "field_two", "type": "int"},
+            ],
+        },
+        {
+            "type": "record",
+            "name": "test_named_schema_disambiguation_in_union",
+            "fields": [
+                {
+                    "name": "item",
+                    "type": [
+                        "null",
+                        "com.example.one_named_type",
+                        "com.example.two_named_type",
+                    ],
+                }
+            ],
+        },
+    ]
+
+    records = [
+        {"item": None},
+        {"item": {"field_one": 42}},
+        {"item": {"field_one": 42, "field_two": 43}},
+    ]
+
+    assert records == roundtrip(schema, records)
+
+
 def test_named_schema_with_logical_type_in_union():
     schema = [
         {


### PR DESCRIPTION
When a union is handed a named schema reference to write, it does not resolve named schemas, and may use an empty set to disambiguate, causing it to select the first type rather than the correct type.
