### PR TITLE
Re-extract record type for a named schema resolved from a union

### DIFF
--- a/fastavro/_write.pyx
+++ b/fastavro/_write.pyx
@@ -312,7 +312,7 @@ cdef write_union(bytearray fo, datum, schema, dict named_schemas, fname, dict op
                 if record_type in named_schemas:
                     # Convert named record types into their full schema so that we can check most_fields
                     candidate = named_schemas[record_type]
-                    record_type = "record"
+                    record_type = extract_record_type(candidate)
 
                 if record_type == "record":
                     logical_type = extract_logical_type(candidate)

--- a/fastavro/_write_py.py
+++ b/fastavro/_write_py.py
@@ -196,7 +196,7 @@ def write_union(encoder, datum, schema, named_schemas, fname, options):
                 if record_type in named_schemas:
                     # Convert named record types into their full schema so that we can check most_fields
                     candidate = named_schemas[record_type]
-                    record_type = "record"
+                    record_type = extract_record_type(candidate)
 
                 if record_type == "record":
                     logical_type = extract_logical_type(candidate)

--- a/tests/test_fastavro.py
+++ b/tests/test_fastavro.py
@@ -1992,7 +1992,9 @@ def test_named_schema_disambiguation_in_union():
             "name": "one_named_type",
             "namespace": "com.example",
             "type": "record",
-            "fields": [{"name": "field_one", "type": "int"}],
+            "fields": [
+                {"name": "field_one", "type": "int"},
+            ],
         },
         {
             "name": "two_named_type",
@@ -2023,6 +2025,33 @@ def test_named_schema_disambiguation_in_union():
         {"item": None},
         {"item": {"field_one": 42}},
         {"item": {"field_one": 42, "field_two": 43}},
+    ]
+
+    assert records == roundtrip(schema, records)
+
+
+def test_named_schema_enum_in_union():
+    schema = [
+        {
+            "name": "an_enum",
+            "namespace": "com.example",
+            "type": "enum",
+            "symbols": ["ONE_SYMBOL", "ANOTHER_SYMBOL"],
+        },
+        {
+            "name": "test_named_schema_enum_in_union",
+            "namespace": "com.example",
+            "type": "record",
+            "fields": [
+                {"name": "field_one", "type": "int"},
+                {"name": "field_two", "type": ["null", "an_enum"]},
+            ],
+        },
+    ]
+
+    records = [
+        {"field_one": 42, "field_two": None},
+        {"field_one": 42, "field_two": "ONE_SYMBOL"},
     ]
 
     assert records == roundtrip(schema, records)


### PR DESCRIPTION
Addresses regression caused by https://github.com/fastavro/fastavro/pull/792 reported in https://github.com/fastavro/fastavro/issues/795