### PR TITLE
Issue 794: Print detailed error messages for out-of-range values when validate int or long type. 

### DIFF
--- a/fastavro/_validate_common.py
+++ b/fastavro/_validate_common.py
@@ -20,3 +20,16 @@ class ValidationError(Exception):
         message = json.dumps([str(e) for e in errors], indent=2, ensure_ascii=False)
         super().__init__(message)
         self.errors = errors
+
+
+class ValidationValueErrorData(
+    namedtuple("ValidationValueErrorData", ["datum", "limit", "field"])
+):
+    def __str__(self):
+        return f"{self.field} <{self.datum}> out of range {self.limit}"
+
+
+class ValidationValueError(ValueError):
+    def __init__(self, error, *args, **kwargs):
+        message = json.dumps(str(error), indent=2, ensure_ascii=False)
+        super().__init__(message, *args, **kwargs)

--- a/fastavro/_validation.pyx
+++ b/fastavro/_validation.pyx
@@ -41,21 +41,27 @@ cdef inline bint validate_bytes(datum):
     return isinstance(datum, (bytes, bytearray))
 
 
-cdef inline bint validate_int(datum):
-    return (
-        isinstance(datum, (int, numbers.Integral))
-        and INT_MIN_VALUE <= datum <= INT_MAX_VALUE
-        and not isinstance(datum, bool)
-    )
+cdef inline bint validate_int(datum, field):
+    if not isinstance(datum, (int, numbers.Integral)) or isinstance(datum, bool):
+        return False
 
+    if datum < INT_MIN_VALUE:
+        raise ValueError(f"too small for int. field({field}): {datum}")
+    if datum > INT_MAX_VALUE:
+        raise OverflowError(f"too large value for int. field({field}): {datum}")
 
-cdef inline bint validate_long(datum):
-    return (
-        isinstance(datum, (int, numbers.Integral))
-        and LONG_MIN_VALUE <= datum <= LONG_MAX_VALUE
-        and not isinstance(datum, bool)
-    )
+    return True
 
+cdef inline bint validate_long(datum, field):
+    if not isinstance(datum, (int, numbers.Integral)) or isinstance(datum, bool):
+        return False
+
+    if datum < LONG_MIN_VALUE:
+        raise ValueError(f"too small for int. field({field}): {datum}")
+    if datum > LONG_MAX_VALUE:
+        raise OverflowError(f"too large value for long. field({field}): {datum}")
+
+    return True
 
 cdef inline bint validate_float(datum):
     return (
@@ -233,9 +239,9 @@ cpdef _validate(
     elif record_type == "string":
         result = validate_string(datum)
     elif record_type == "int":
-        result = validate_int(datum)
+        result = validate_int(datum, field)
     elif record_type == "long":
-        result = validate_long(datum)
+        result = validate_long(datum, field)
     elif record_type in ("float", "double"):
         result = validate_float(datum)
     elif record_type == "bytes":

--- a/fastavro/_validation.pyx
+++ b/fastavro/_validation.pyx
@@ -10,7 +10,7 @@ from ._schema import (
 )
 from ._logical_writers import LOGICAL_WRITERS
 from ._schema_common import UnknownType
-from ._validate_common import ValidationError, ValidationErrorData
+from ._validate_common import ValidationError, ValidationValueError, ValidationErrorData, ValidationValueErrorData
 
 ctypedef int int32
 ctypedef unsigned int uint32
@@ -46,9 +46,10 @@ cdef inline bint validate_int(datum, field):
         return False
 
     if datum < INT_MIN_VALUE:
-        raise ValueError(f"too small for int. field({field}): {datum}")
+        raise ValidationValueError(ValidationValueErrorData(datum, INT_MIN_VALUE, field))
     if datum > INT_MAX_VALUE:
-        raise OverflowError(f"too large value for int. field({field}): {datum}")
+        raise ValidationValueError(ValidationValueErrorData(datum, INT_MAX_VALUE, field))
+
 
     return True
 
@@ -57,9 +58,9 @@ cdef inline bint validate_long(datum, field):
         return False
 
     if datum < LONG_MIN_VALUE:
-        raise ValueError(f"too small for int. field({field}): {datum}")
+        raise ValidationValueError(ValidationValueErrorData(datum, LONG_MIN_VALUE, field))
     if datum > LONG_MAX_VALUE:
-        raise OverflowError(f"too large value for long. field({field}): {datum}")
+        raise ValidationValueError(ValidationValueErrorData(datum, LONG_MAX_VALUE, field))
 
     return True
 

--- a/fastavro/_validation_py.py
+++ b/fastavro/_validation_py.py
@@ -4,7 +4,12 @@ from collections.abc import Mapping, Sequence
 from typing import Any, Iterable
 
 from .const import INT_MAX_VALUE, INT_MIN_VALUE, LONG_MAX_VALUE, LONG_MIN_VALUE
-from ._validate_common import ValidationError, ValidationErrorData
+from ._validate_common import (
+    ValidationError,
+    ValidationValueError,
+    ValidationErrorData,
+    ValidationValueErrorData,
+)
 from .schema import extract_record_type, extract_logical_type, schema_name, parse_schema
 from .logical_writers import LOGICAL_WRITERS
 from ._schema_common import UnknownType
@@ -42,11 +47,20 @@ def _validate_int(datum, **kwargs):
 
     conditional python types: int, numbers.Integral
     """
-    return (
-        isinstance(datum, (int, numbers.Integral))
-        and INT_MIN_VALUE <= datum <= INT_MAX_VALUE
-        and not isinstance(datum, bool)
-    )
+    if not isinstance(datum, (int, numbers.Integral)) or isinstance(datum, bool):
+        return False
+
+    if datum < INT_MIN_VALUE:
+        raise ValidationValueError(
+            ValidationValueErrorData(datum, INT_MIN_VALUE, kwargs.get("field", ""))
+        )
+
+    if datum > INT_MAX_VALUE:
+        raise ValidationValueError(
+            ValidationValueErrorData(datum, INT_MAX_VALUE, kwargs.get("field", ""))
+        )
+
+    return True
 
 
 def _validate_long(datum, **kwargs):
@@ -58,11 +72,20 @@ def _validate_long(datum, **kwargs):
 
     conditional python types: int, numbers.Integral
     """
-    return (
-        isinstance(datum, (int, numbers.Integral))
-        and LONG_MIN_VALUE <= datum <= LONG_MAX_VALUE
-        and not isinstance(datum, bool)
-    )
+    if not isinstance(datum, (int, numbers.Integral)) or isinstance(datum, bool):
+        return False
+
+    if datum < LONG_MIN_VALUE:
+        raise ValidationValueError(
+            ValidationValueErrorData(datum, LONG_MIN_VALUE, kwargs.get("field", ""))
+        )
+
+    if datum > LONG_MAX_VALUE:
+        raise ValidationValueError(
+            ValidationValueErrorData(datum, LONG_MAX_VALUE, kwargs.get("field", ""))
+        )
+
+    return True
 
 
 def _validate_float(datum, **kwargs):

--- a/fastavro/validation.py
+++ b/fastavro/validation.py
@@ -2,7 +2,12 @@ try:
     from . import _validation
 except ImportError:
     from . import _validation_py as _validation  # type: ignore
-from ._validate_common import ValidationErrorData, ValidationError
+from ._validate_common import (
+    ValidationErrorData,
+    ValidationError,
+    ValidationValueErrorData,
+    ValidationValueError,
+)
 
 # Private API
 _validate = _validation._validate  # type: ignore
@@ -11,4 +16,11 @@ _validate = _validation._validate  # type: ignore
 validate = _validation.validate
 validate_many = _validation.validate_many
 
-__all__ = ["ValidationError", "ValidationErrorData", "validate", "validate_many"]
+__all__ = [
+    "ValidationError",
+    "ValidationErrorData",
+    "ValidationValueErrorData",
+    "ValidationValueError",
+    "validate",
+    "validate_many",
+]

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -2,10 +2,12 @@
 from fastavro.validation import (
     ValidationError,
     ValidationErrorData,
+    ValidationValueError,
     validate,
     validate_many,
 )
 from fastavro import parse_schema
+from fastavro.const import INT_MIN_VALUE, INT_MAX_VALUE, LONG_MIN_VALUE, LONG_MAX_VALUE
 import pytest
 import numpy as np
 from datetime import datetime
@@ -612,3 +614,41 @@ def test_validate_strict():
 
     with pytest.raises(ValidationError):
         validate_many([record], parsed_schema, strict=True)
+
+
+INT_UNION = ["int"]
+LONG_UNION = ["long"]
+INT_LONG_UNION = ["int", "long"]
+INT_FLOAT_UNION = ["int", "float"]
+INT_LONG_FLOAT_DOUBLE_UNION = ["int", "long", "float", "double"]
+INT_STRING_UNION = ["int", "string"]
+
+
+@pytest.mark.parametrize(
+    "schema,out_of_range_data",
+    [
+        ("int", INT_MIN_VALUE - 1),
+        ("int", INT_MAX_VALUE + 1),
+        ("long", LONG_MIN_VALUE - 1),
+        ("long", LONG_MAX_VALUE + 1),
+        (INT_UNION, INT_MIN_VALUE - 1),
+        (INT_UNION, INT_MAX_VALUE + 1),
+        (LONG_UNION, LONG_MIN_VALUE - 1),
+        (LONG_UNION, LONG_MAX_VALUE + 1),
+        (INT_LONG_UNION, LONG_MIN_VALUE - 1),
+        (INT_LONG_UNION, LONG_MAX_VALUE + 1),
+        (INT_LONG_UNION, INT_MIN_VALUE - 1),
+        (INT_LONG_UNION, INT_MAX_VALUE + 1),
+        (INT_FLOAT_UNION, INT_MIN_VALUE - 1),
+        (INT_FLOAT_UNION, INT_MAX_VALUE + 1),
+        (INT_LONG_FLOAT_DOUBLE_UNION, INT_MIN_VALUE - 1),
+        (INT_LONG_FLOAT_DOUBLE_UNION, INT_MAX_VALUE + 1),
+        (INT_LONG_FLOAT_DOUBLE_UNION, LONG_MIN_VALUE - 1),
+        (INT_LONG_FLOAT_DOUBLE_UNION, LONG_MAX_VALUE + 1),
+        (INT_STRING_UNION, INT_MIN_VALUE - 1),
+        (INT_STRING_UNION, INT_MAX_VALUE + 1),
+    ],
+)
+def test_validate_out_of_range(schema, out_of_range_data):
+    with pytest.raises(ValidationValueError):
+        validate(out_of_range_data, schema)

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -1,4 +1,7 @@
 # -*- coding: utf-8 -*-
+import random
+import string
+
 from fastavro.validation import (
     ValidationError,
     ValidationErrorData,
@@ -625,30 +628,36 @@ INT_STRING_UNION = ["int", "string"]
 
 
 @pytest.mark.parametrize(
-    "schema,out_of_range_data",
+    "schema,limit,write_data",
     [
-        ("int", INT_MIN_VALUE - 1),
-        ("int", INT_MAX_VALUE + 1),
-        ("long", LONG_MIN_VALUE - 1),
-        ("long", LONG_MAX_VALUE + 1),
-        (INT_UNION, INT_MIN_VALUE - 1),
-        (INT_UNION, INT_MAX_VALUE + 1),
-        (LONG_UNION, LONG_MIN_VALUE - 1),
-        (LONG_UNION, LONG_MAX_VALUE + 1),
-        (INT_LONG_UNION, LONG_MIN_VALUE - 1),
-        (INT_LONG_UNION, LONG_MAX_VALUE + 1),
-        (INT_LONG_UNION, INT_MIN_VALUE - 1),
-        (INT_LONG_UNION, INT_MAX_VALUE + 1),
-        (INT_FLOAT_UNION, INT_MIN_VALUE - 1),
-        (INT_FLOAT_UNION, INT_MAX_VALUE + 1),
-        (INT_LONG_FLOAT_DOUBLE_UNION, INT_MIN_VALUE - 1),
-        (INT_LONG_FLOAT_DOUBLE_UNION, INT_MAX_VALUE + 1),
-        (INT_LONG_FLOAT_DOUBLE_UNION, LONG_MIN_VALUE - 1),
-        (INT_LONG_FLOAT_DOUBLE_UNION, LONG_MAX_VALUE + 1),
-        (INT_STRING_UNION, INT_MIN_VALUE - 1),
-        (INT_STRING_UNION, INT_MAX_VALUE + 1),
+        ("int", INT_MIN_VALUE, INT_MIN_VALUE - 1),
+        ("int", INT_MAX_VALUE, INT_MAX_VALUE + 1),
+        ("long", LONG_MIN_VALUE, LONG_MIN_VALUE - 1),
+        ("long", LONG_MAX_VALUE, LONG_MAX_VALUE + 1),
+        (INT_UNION, INT_MIN_VALUE, INT_MIN_VALUE - 1),
+        (INT_UNION, INT_MAX_VALUE, INT_MAX_VALUE + 1),
+        (LONG_UNION, LONG_MIN_VALUE, LONG_MIN_VALUE - 1),
+        (LONG_UNION, LONG_MAX_VALUE, LONG_MAX_VALUE + 1),
+        (INT_LONG_UNION, INT_MIN_VALUE, LONG_MIN_VALUE - 1),
+        (INT_LONG_UNION, INT_MAX_VALUE, LONG_MAX_VALUE + 1),
+        (INT_LONG_UNION, INT_MIN_VALUE, INT_MIN_VALUE - 1),
+        (INT_LONG_UNION, INT_MAX_VALUE, INT_MAX_VALUE + 1),
+        (INT_FLOAT_UNION, INT_MIN_VALUE, INT_MIN_VALUE - 1),
+        (INT_FLOAT_UNION, INT_MAX_VALUE, INT_MAX_VALUE + 1),
+        (INT_LONG_FLOAT_DOUBLE_UNION, INT_MIN_VALUE, INT_MIN_VALUE - 1),
+        (INT_LONG_FLOAT_DOUBLE_UNION, INT_MAX_VALUE, INT_MAX_VALUE + 1),
+        (INT_LONG_FLOAT_DOUBLE_UNION, INT_MIN_VALUE, LONG_MIN_VALUE - 1),
+        (INT_LONG_FLOAT_DOUBLE_UNION, INT_MAX_VALUE, LONG_MAX_VALUE + 1),
+        (INT_STRING_UNION, INT_MIN_VALUE, INT_MIN_VALUE - 1),
+        (INT_STRING_UNION, INT_MAX_VALUE, INT_MAX_VALUE + 1),
     ],
 )
-def test_validate_out_of_range(schema, out_of_range_data):
-    with pytest.raises(ValidationValueError):
-        validate(out_of_range_data, schema)
+def test_validate_out_of_range(schema, limit, write_data):
+    field = "".join(
+        random.choice(string.ascii_letters) for _ in range(random.randint(0, 2))
+    )
+
+    with pytest.raises(ValidationValueError) as e:
+        validate(write_data, schema, field)
+
+    assert str(e.value) == f'"{field} <{write_data}> out of range {limit}"'

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -1,0 +1,74 @@
+from fastavro.const import INT_MIN_VALUE, INT_MAX_VALUE, LONG_MIN_VALUE, LONG_MAX_VALUE
+from fastavro.validation import ValidationValueError
+
+import fastavro
+
+import pytest
+
+from io import BytesIO
+
+INT_ARRAY = {"type": "array", "items": "int"}
+LONG_ARRAY = {"type": "array", "items": "long"}
+INT_MAP = {"type": "map", "values": "int"}
+LONG_MAP = {"type": "map", "values": "long"}
+INT_UNION = ["int"]
+LONG_UNION = ["long"]
+INT_LONG_UNION = ["int", "long"]
+INT_FLOAT_UNION = ["int", "float"]
+INT_LONG_FLOAT_DOUBLE_UNION = ["int", "long", "float", "double"]
+INT_STRING_UNION = ["int", "string"]
+STRING_INT_UNION = ["string", "int"]
+
+
+@pytest.mark.parametrize(
+    "writer_schema,write_data",
+    [
+        ("int", INT_MIN_VALUE - 1),
+        ("int", INT_MAX_VALUE + 1),
+        # ("long", LONG_MIN_VALUE - 1),
+        # ("long", LONG_MAX_VALUE + 1),
+        (INT_LONG_UNION, INT_MIN_VALUE - 1),
+        (INT_LONG_UNION, INT_MAX_VALUE + 1),
+        (INT_FLOAT_UNION, INT_MIN_VALUE - 1),
+        (INT_FLOAT_UNION, INT_MAX_VALUE + 1),
+        (INT_LONG_FLOAT_DOUBLE_UNION, INT_MIN_VALUE - 1),
+        (INT_LONG_FLOAT_DOUBLE_UNION, INT_MAX_VALUE + 1),
+        (INT_LONG_FLOAT_DOUBLE_UNION, LONG_MIN_VALUE - 1),
+        (INT_LONG_FLOAT_DOUBLE_UNION, LONG_MAX_VALUE + 1),
+    ],
+)
+def test_writer(writer_schema, write_data):
+    bio = BytesIO()
+    fastavro.writer(bio, writer_schema, [write_data])
+
+
+@pytest.mark.parametrize(
+    "writer_schema,write_data",
+    [
+        ("int", INT_MIN_VALUE - 1),
+        ("int", INT_MAX_VALUE + 1),
+        ("long", LONG_MIN_VALUE - 1),
+        ("long", LONG_MAX_VALUE + 1),
+    ],
+)
+def test_writer_with_validator(writer_schema, write_data):
+    with pytest.raises(ValidationValueError):
+        bio = BytesIO()
+        fastavro.writer(bio, writer_schema, [write_data], validator=True)
+
+
+@pytest.mark.parametrize(
+    "writer_schema,write_data",
+    [
+        (INT_UNION, INT_MIN_VALUE - 1),
+        (INT_UNION, INT_MAX_VALUE + 1),
+        (LONG_UNION, LONG_MIN_VALUE - 1),
+        (LONG_UNION, LONG_MAX_VALUE + 1),
+        (INT_LONG_UNION, LONG_MIN_VALUE - 1),
+        (INT_LONG_UNION, LONG_MAX_VALUE + 1),
+    ],
+)
+def test_out_of_range_union_write(writer_schema, write_data):
+    with pytest.raises(ValidationValueError):
+        bio = BytesIO()
+        fastavro.writer(bio, writer_schema, [write_data])

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -7,10 +7,6 @@ import pytest
 
 from io import BytesIO
 
-INT_ARRAY = {"type": "array", "items": "int"}
-LONG_ARRAY = {"type": "array", "items": "long"}
-INT_MAP = {"type": "map", "values": "int"}
-LONG_MAP = {"type": "map", "values": "long"}
 INT_UNION = ["int"]
 LONG_UNION = ["long"]
 INT_LONG_UNION = ["int", "long"]


### PR DESCRIPTION
## Title
print detailed error messages for out-of-range values when validate int or long type. 

## Changes
- Error messages now include the field name and the problematic value to give more context to the user.
- Introduced ValueError and OverflowError to signal when datum is too small or too large, respectively.
- The function now raises:
ValueError if datum is smaller than INT_MIN_VALUE, LONG_MIN_VALUE.
OverflowError if datum exceeds INT_MAX_VALUE, LONG_MAX_VALUE.
- bool values are explicitly checked and rejected to avoid being treated as integers before range validation


## Related issues
https://github.com/fastavro/fastavro/issues/794
