### PR TITLE
Rename the argument with a default value in an internal helper.

### DIFF
--- a/fastavro/_schema.pyx
+++ b/fastavro/_schema.pyx
@@ -558,7 +558,8 @@ cdef _parse_schema_with_repo(
         )
 
 
-cdef _inject_schema(outer_schema, inner_schema, namespace="", is_injected=False):
+cdef _inject_schema(outer_schema, inner_schema, ns="", is_injected=False):
+    namespace = ns  # Avoids a conflict with a C++ keyword in Cythonized path.
     # Once injected, we can stop checking to see if we need to inject since it
     # should only be done once at most
     if is_injected is True:

--- a/fastavro/_schema_py.py
+++ b/fastavro/_schema_py.py
@@ -745,7 +745,8 @@ def _parse_schema_with_repo(
         )
 
 
-def _inject_schema(outer_schema, inner_schema, namespace="", is_injected=False):
+def _inject_schema(outer_schema, inner_schema, ns="", is_injected=False):
+    namespace = ns  # Avoids a conflict with a C++ keyword in Cythonized path.
     # Once injected, we can stop checking to see if we need to inject since it
     # should only be done once at most
     if is_injected is True:


### PR DESCRIPTION
The keyword argument 'namespace' has a default value. Cython translates the header function into the following C code to handle optional arguments with a default value:

```
/* "fastavro/_schema.pyx":561
 * 
 * 
 * cdef _inject_schema(outer_schema, inner_schema, namespace="", is_injected=False):             # <<<<<<<<<<<<<<
 *     # Once injected, we can stop checking to see if we need to inject since it
 *     # should only be done once at most
 */
struct __pyx_opt_args_8fastavro_7_schema__inject_schema {
  int __pyx_n;
  PyObject *namespace;
  PyObject *is_injected;
};
...
```

The  `PyObject *namespace;` causes compiler errors if an extension is built with a C++ compiler. My PR  offers a workaround to avoid that collision. 

Also asked about this in[ cython-users group](https://groups.google.com/g/cython-users/c/qIJzaBurOWg).