### PR TITLE
Refactor timing calculations using statistics.mean() 

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ fork of [fastavro-feedstock][feedstock].
 
 * Make sure the tests pass
 * Run `make tag`
-* Wait for all artifacts to be built and published the the Github release
+* Wait for all artifacts to be built and published to the GitHub release.
 * Run `make publish`
 * The conda-forge PR should get created and merged automatically
 

--- a/benchmark/benchmark.py
+++ b/benchmark/benchmark.py
@@ -31,7 +31,7 @@ def write_schemaless(schema, records, runs=1):
             schemaless_writer(iostream, schema, record)
             end = time.time()
             times.append(end - start)
-    print(f'... {runs} runs averaged {sum(times) / runs} seconds')
+    print(f'... {runs} runs averaged {statistics.mean(times):.6f} seconds')
     return iostream
 
 
@@ -44,7 +44,7 @@ def validater(schema, records, runs=1):
         valid = validate_many(records, schema)
         end = time.time()
         times.append(end - start)
-    print(f'... {runs} runs averaged {sum(times) / runs} seconds')
+    print(f'... {runs} runs averaged {statistics.mean(times):.6f} seconds')
     return valid
 
 
@@ -56,7 +56,7 @@ def read(iostream, runs=1):
         records = list(reader(iostream))
         end = time.time()
         times.append(end - start)
-    print(f'... {runs} runs averaged {sum(times) / runs} seconds')
+    print(f'... {runs} runs averaged {statistics.mean(times):.6f} seconds')
     return records
 
 
@@ -70,7 +70,7 @@ def read_schemaless(iostream, schema, num_records, runs=1):
             record = schemaless_reader(iostream, schema)
             end = time.time()
             times.append(end - start)
-    print(f'... {runs} runs averaged {sum(times) / runs} seconds')
+    print(f'... {runs} runs averaged {statistics.mean(times):.6f} seconds')
     return record
 
 

--- a/benchmark/benchmark.py
+++ b/benchmark/benchmark.py
@@ -1,6 +1,7 @@
 from io import BytesIO
 from datetime import datetime, timezone
 import time
+import statistics
 
 from fastavro import writer, reader, schemaless_writer, schemaless_reader, parse_schema
 
@@ -16,7 +17,7 @@ def write(schema, records, runs=1):
         writer(iostream, schema, records)
         end = time.time()
         times.append(end - start)
-    print(f'... {runs} runs averaged {sum(times) / runs} seconds')
+    print(f'... {runs} runs averaged {statistics.mean(times):.6f} seconds')
     return iostream
 
 


### PR DESCRIPTION
**1. Replaced sum(times) / runs with statistics.mean(times)**
_Why?_

1. **Readability**: statistics.mean(times) is more explicit and clearly conveys that we are calculating the mean.
2. **Robustness**: Using sum(times) / runs manually requires ensuring runs is never 0, whereas statistics.mean() handles empty lists gracefully by raising a StatisticsError, which is more informative for debugging.
3. **Extensibility**: statistics provides other statistical functions (median, variance, standard deviation), which can be easily integrated in the future.

**2. Added .6f Formatting for Floating-Point Precision**
_Why?_

1. Ensures consistent output format for easier comparison across different test cases.
2. Limits unnecessary decimal places, preventing excessive precision that doesn’t add value.
3. Helps in benchmarking, as more readable values are easier to interpret.

**Overall Benefits of the Changes**
✅ Improves Code Readability – statistics.mean() makes the intent explicit.
✅ Prevents Potential Division by Zero – mean() raises a StatisticsError, providing a meaningful failure message.
✅ Enhances Code Maintainability – Future statistical enhancements (e.g., adding variance/std dev) will be easier.
✅ Standardized Output Format – Floating-point precision ensures clear and uniform output.