### PR TITLE
Improve performance for schema resolution

### DIFF
--- a/fastavro/_read.pyx
+++ b/fastavro/_read.pyx
@@ -82,7 +82,6 @@ cpdef match_types(writer_type, reader_type, named_schemas):
 
 
 cpdef match_schemas(w_schema, r_schema, named_schemas):
-    error_msg = f"Schema mismatch: {w_schema} is not {r_schema}"
     if isinstance(w_schema, list):
         # If the writer is a union, checks will happen in read_union after the
         # correct schema is known
@@ -94,7 +93,9 @@ cpdef match_schemas(w_schema, r_schema, named_schemas):
             if match_types(w_schema, schema, named_schemas):
                 return schema
         else:
-            raise SchemaResolutionError(error_msg)
+            raise SchemaResolutionError(
+                f"Schema mismatch: {w_schema} is not {r_schema}"
+            )
     else:
         # Check for dicts as primitive types are just strings
         if isinstance(w_schema, dict):
@@ -128,7 +129,7 @@ cpdef match_schemas(w_schema, r_schema, named_schemas):
                 return r_schema["name"]
         elif match_types(w_type, r_type, named_schemas):
             return r_schema
-        raise SchemaResolutionError(error_msg)
+        raise SchemaResolutionError(f"Schema mismatch: {w_schema} is not {r_schema}")
 
 
 cpdef inline read_null(fo):
@@ -528,7 +529,6 @@ cpdef read_union(
     idx_reader_schema = None
 
     if reader_schema:
-        msg = f"schema mismatch: {writer_schema} not found in {reader_schema}"
         # Handle case where the reader schema is just a single type (not union)
         if not isinstance(reader_schema, list):
             if match_types(idx_schema, reader_schema, named_schemas):
@@ -540,7 +540,9 @@ cpdef read_union(
                     options,
                 )
             else:
-                raise SchemaResolutionError(msg)
+                raise SchemaResolutionError(
+                    f"schema mismatch: {writer_schema} not found in {reader_schema}"
+                )
         else:
             for schema in reader_schema:
                 if match_types(idx_schema, schema, named_schemas):
@@ -554,7 +556,9 @@ cpdef read_union(
                     )
                     break
             else:
-                raise SchemaResolutionError(msg)
+                raise SchemaResolutionError(
+                    f"schema mismatch: {writer_schema} not found in {reader_schema}"
+                )
     else:
         result = _read_data(fo, idx_schema, named_schemas, None, options)
 
@@ -668,7 +672,7 @@ cpdef read_record(
 
         # fill in default values
         if len(readers_field_dict) > len(record):
-            writer_fields = [f["name"] for f in writer_schema["fields"]]
+            writer_fields = {f["name"] for f in writer_schema["fields"]}
             for f_name, field in readers_field_dict.items():
                 if f_name not in writer_fields and f_name not in record:
                     if "default" in field:

--- a/fastavro/_read.pyx
+++ b/fastavro/_read.pyx
@@ -57,10 +57,10 @@ cpdef match_types(writer_type, reader_type, named_schemas):
     if isinstance(writer_type, list) or isinstance(reader_type, list):
         return True
     if isinstance(writer_type, dict) or isinstance(reader_type, dict):
-        try:
-            return match_schemas(writer_type, reader_type, named_schemas)
-        except SchemaResolutionError:
-            return False
+        matching_schema = match_schemas(
+            writer_type, reader_type, named_schemas, raise_on_error=False
+        )
+        return matching_schema is not None
     if writer_type == reader_type:
         return True
     # promotion cases
@@ -81,7 +81,7 @@ cpdef match_types(writer_type, reader_type, named_schemas):
     return False
 
 
-cpdef match_schemas(w_schema, r_schema, named_schemas):
+cpdef match_schemas(w_schema, r_schema, named_schemas, raise_on_error=True):
     if isinstance(w_schema, list):
         # If the writer is a union, checks will happen in read_union after the
         # correct schema is known
@@ -93,9 +93,12 @@ cpdef match_schemas(w_schema, r_schema, named_schemas):
             if match_types(w_schema, schema, named_schemas):
                 return schema
         else:
-            raise SchemaResolutionError(
-                f"Schema mismatch: {w_schema} is not {r_schema}"
-            )
+            if raise_on_error:
+                raise SchemaResolutionError(
+                    f"Schema mismatch: {w_schema} is not {r_schema}"
+                )
+            else:
+                return None
     else:
         # Check for dicts as primitive types are just strings
         if isinstance(w_schema, dict):
@@ -115,9 +118,12 @@ cpdef match_schemas(w_schema, r_schema, named_schemas):
                 return r_schema
         elif w_type in NAMED_TYPES and r_type in NAMED_TYPES:
             if w_type == r_type == "fixed" and w_schema["size"] != r_schema["size"]:
-                raise SchemaResolutionError(
-                    f"Schema mismatch: {w_schema} size is different than {r_schema} size"
-                )
+                if raise_on_error:
+                    raise SchemaResolutionError(
+                        f"Schema mismatch: {w_schema} size is different than {r_schema} size"
+                    )
+                else:
+                    return None
 
             w_unqual_name = w_schema["name"].split(".")[-1]
             r_unqual_name = r_schema["name"].split(".")[-1]
@@ -129,7 +135,12 @@ cpdef match_schemas(w_schema, r_schema, named_schemas):
                 return r_schema["name"]
         elif match_types(w_type, r_type, named_schemas):
             return r_schema
-        raise SchemaResolutionError(f"Schema mismatch: {w_schema} is not {r_schema}")
+        if raise_on_error:
+            raise SchemaResolutionError(
+                f"Schema mismatch: {w_schema} is not {r_schema}"
+            )
+        else:
+            return None
 
 
 cpdef inline read_null(fo):

--- a/fastavro/_read.pyx
+++ b/fastavro/_read.pyx
@@ -660,26 +660,25 @@ cpdef read_record(
                 aliases_field_dict.get(field["name"]),
             )
             if readers_field:
-                record[readers_field["name"]] = _read_data(
+                readers_field_name = readers_field["name"]
+                record[readers_field_name] = _read_data(
                     fo,
                     field["type"],
                     named_schemas,
                     readers_field["type"],
                     options,
                 )
+                del readers_field_dict[readers_field_name]
             else:
                 _skip_data(fo, field["type"], named_schemas)
 
         # fill in default values
-        if len(readers_field_dict) > len(record):
-            writer_fields = {f["name"] for f in writer_schema["fields"]}
-            for f_name, field in readers_field_dict.items():
-                if f_name not in writer_fields and f_name not in record:
-                    if "default" in field:
-                        record[field["name"]] = field["default"]
-                    else:
-                        msg = f"No default value for field {field['name']} in {reader_schema['name']}"
-                        raise SchemaResolutionError(msg)
+        for f_name, field in readers_field_dict.items():
+            if "default" in field:
+                record[field["name"]] = field["default"]
+            else:
+                msg = f"No default value for field {field['name']} in {reader_schema['name']}"
+                raise SchemaResolutionError(msg)
 
     return record
 

--- a/fastavro/_read_py.py
+++ b/fastavro/_read_py.py
@@ -75,7 +75,6 @@ def match_types(writer_type, reader_type, named_schemas):
 
 
 def match_schemas(w_schema, r_schema, named_schemas):
-    error_msg = f"Schema mismatch: {w_schema} is not {r_schema}"
     if isinstance(w_schema, list):
         # If the writer is a union, checks will happen in read_union after the
         # correct schema is known
@@ -87,7 +86,9 @@ def match_schemas(w_schema, r_schema, named_schemas):
             if match_types(w_schema, schema, named_schemas):
                 return schema
         else:
-            raise SchemaResolutionError(error_msg)
+            raise SchemaResolutionError(
+                f"Schema mismatch: {w_schema} is not {r_schema}"
+            )
     else:
         # Check for dicts as primitive types are just strings
         if isinstance(w_schema, dict):
@@ -125,7 +126,7 @@ def match_schemas(w_schema, r_schema, named_schemas):
                 return r_schema["name"]
         elif match_types(w_type, r_type, named_schemas):
             return r_schema
-        raise SchemaResolutionError(error_msg)
+        raise SchemaResolutionError(f"Schema mismatch: {w_schema} is not {r_schema}")
 
 
 def read_null(
@@ -403,7 +404,6 @@ def read_union(
     idx_reader_schema = None
 
     if reader_schema:
-        msg = f"schema mismatch: {writer_schema} not found in {reader_schema}"
         # Handle case where the reader schema is just a single type (not union)
         if not isinstance(reader_schema, list):
             if match_types(idx_schema, reader_schema, named_schemas):
@@ -415,7 +415,9 @@ def read_union(
                     options,
                 )
             else:
-                raise SchemaResolutionError(msg)
+                raise SchemaResolutionError(
+                    f"schema mismatch: {writer_schema} not found in {reader_schema}"
+                )
         else:
             for schema in reader_schema:
                 if match_types(idx_schema, schema, named_schemas):
@@ -429,7 +431,9 @@ def read_union(
                     )
                     break
             else:
-                raise SchemaResolutionError(msg)
+                raise SchemaResolutionError(
+                    f"schema mismatch: {writer_schema} not found in {reader_schema}"
+                )
     else:
         result = read_data(decoder, idx_schema, named_schemas, None, options)
 
@@ -538,7 +542,7 @@ def read_record(
 
         # fill in default values
         if len(readers_field_dict) > len(record):
-            writer_fields = [f["name"] for f in writer_schema["fields"]]
+            writer_fields = {f["name"] for f in writer_schema["fields"]}
             for f_name, field in readers_field_dict.items():
                 if f_name not in writer_fields and f_name not in record:
                     if "default" in field:

--- a/fastavro/_read_py.py
+++ b/fastavro/_read_py.py
@@ -530,26 +530,25 @@ def read_record(
                 aliases_field_dict.get(field["name"]),
             )
             if readers_field:
-                record[readers_field["name"]] = read_data(
+                readers_field_name = readers_field["name"]
+                record[readers_field_name] = read_data(
                     decoder,
                     field["type"],
                     named_schemas,
                     readers_field["type"],
                     options,
                 )
+                del readers_field_dict[readers_field_name]
             else:
                 skip_data(decoder, field["type"], named_schemas)
 
         # fill in default values
-        if len(readers_field_dict) > len(record):
-            writer_fields = {f["name"] for f in writer_schema["fields"]}
-            for f_name, field in readers_field_dict.items():
-                if f_name not in writer_fields and f_name not in record:
-                    if "default" in field:
-                        record[field["name"]] = field["default"]
-                    else:
-                        msg = f"No default value for field {field['name']} in {reader_schema['name']}"
-                        raise SchemaResolutionError(msg)
+        for f_name, field in readers_field_dict.items():
+            if "default" in field:
+                record[field["name"]] = field["default"]
+            else:
+                msg = f"No default value for field {field['name']} in {reader_schema['name']}"
+                raise SchemaResolutionError(msg)
 
     return record
 


### PR DESCRIPTION
I observered a big slowdown when using a different writer and reader schema compared to writer schema == reader schema. 

This can be reproduced with this script:

```python
import io
import random
import time
from contextlib import contextmanager

import fastavro
import fastavro.utils

print(fastavro)


def generate_big_schema(field_count):
    def field_nr(nr: int):
        return {
            "name": f"field_{nr}",
            "type": "int",
            "default": field_count,
            "doc": "Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam"
        }

    return {
        "type": "record",
        "name": "BigSchema",
        "fields": [field_nr(nr) for nr in range(field_count)]
    }


WRITER_SCHEMA = fastavro.schema.parse_schema(generate_big_schema(100))
READER_SCHEMA = fastavro.schema.parse_schema(generate_big_schema(101))


def serialize(msg):
    buffer = io.BytesIO()
    fastavro.schemaless_writer(buffer, WRITER_SCHEMA, msg)
    return buffer.getvalue()


@contextmanager
def timer(name):
    start = time.perf_counter()
    yield
    stop = time.perf_counter()
    print(f"{name}: {stop - start}s")


random.seed("foobar")
raw_message = serialize({})

measure = True
if measure:
    ITERATIONS = 100000
    with timer("no resolution"):
        for _ in range(ITERATIONS):
            fastavro.schemaless_reader(io.BytesIO(raw_message), WRITER_SCHEMA, reader_schema=None)

    with timer("resolution"):
        for _ in range(ITERATIONS):
            fastavro.schemaless_reader(io.BytesIO(raw_message), WRITER_SCHEMA, reader_schema=READER_SCHEMA)
else:
    ITERATIONS = 1000
    for _ in range(ITERATIONS):
        fastavro.schemaless_reader(io.BytesIO(raw_message), WRITER_SCHEMA, reader_schema=READER_SCHEMA)
```


on my machine it prints:

```
$ python resolution_bench.py 
<module 'fastavro' from '/tmp/venv/lib/python3.10/site-packages/fastavro/__init__.py'>
no resolution: 0.6873706740007037s
resolution: 22.573060028997133s
```

I investigated this a bit using valgrind(callgrind) and saw that the following function took a lot of time:

- PyObject_Repr
- PySequence_Contains

To improve this i changed:

- only build error messages on demand. in some cases the schema was formatted into a string, which can be expansive for big schemas (e.g. big doc string as in the script)
- use a set instead of a list where appropriate

with these changes i now get:

```
no resolution: 0.9697164819954196s
resolution: 3.084980943996925s
```

The ~3x slowdown is still not optimal i guess, but better than before

