### PR TITLE
Add default value to optional argument in type stub

### DIFF
--- a/fastavro/_read.pyi
+++ b/fastavro/_read.pyi
@@ -79,7 +79,7 @@ class Block:
 def schemaless_reader(
     fo: IO,
     writer_schema: Schema,
-    reader_schema: Optional[Schema],
+    reader_schema: Optional[Schema] = ...,
     return_record_name: bool = ...,
     return_record_name_override: bool = ...,
     handle_unicode_errors: str = ...,


### PR DESCRIPTION
Hi,

Running `mypy` (both with and without `--strict`) on the following script:
```python
import io
import fastavro


schema = {
    "type": "record",
    "name": "foo",
    "fields": [
        {
            "name": "bar",
            "type": "int",
        },
    ],
}


record = {"bar": 10}


with io.BytesIO() as fb:
    fastavro.write.schemaless_writer(
        fo=fb,
        schema=schema,
        record=record,
    )
    bs = fb.getvalue()

with io.BytesIO(bs) as fb:
    out_record = fastavro.read.schemaless_reader(
        fo=fb,
        writer_schema=schema,
    )


assert record == out_record
```
results in the error `error: Too few arguments  [call-arg]` if `reader_schema` is not explicitly given a value. It is set to `None` by default, but not in the `_read.pyi`-type stub. Adding an ellipsis to the argument in the type stub removes the error.

This is tested using Python 3.13.9, `fastavro == 1.12.1` and `mypy == 1.18.2`.