### PR TITLE
Use zstandard implementation from stdlib (PEP-784)

### DIFF
--- a/developer_requirements.txt
+++ b/developer_requirements.txt
@@ -13,7 +13,7 @@ black; implementation_name != "pypy"
 
 # codec libraries (snappy is intentionally left off this list as it requires other system libraries to be installed and is non-trivial)
 cramjam
+backports.zstd ; python_version<'3.14'
 # Also don't install on windows for similar reasons
-zstandard; sys_platform != 'win32'
 lz4; sys_platform != 'win32'
 zlib_ng

--- a/fastavro/_read.pyx
+++ b/fastavro/_read.pyx
@@ -8,6 +8,7 @@
 
 import bz2
 import lzma
+import sys
 import zlib
 from datetime import datetime, timezone
 from decimal import Context
@@ -915,13 +916,16 @@ else:
 cpdef zstandard_read_block(fo):
     length = read_long(fo)
     data = fo.read(length)
-    return BytesIO(zstd.ZstdDecompressor().decompressobj().decompress(data))
+    return BytesIO(zstd.decompress(data))
 
 
 try:
-    import zstandard as zstd
+    if sys.version_info >= (3, 14):
+        from compression import zstd
+    else:
+        from backports import zstd
 except ImportError:
-    BLOCK_READERS["zstandard"] = missing_codec_lib("zstandard", "zstandard")
+    BLOCK_READERS["zstandard"] = missing_codec_lib("zstandard", "backports.zstd")
 else:
     BLOCK_READERS["zstandard"] = zstandard_read_block
 

--- a/fastavro/_read_py.py
+++ b/fastavro/_read_py.py
@@ -7,6 +7,7 @@
 import bz2
 import json
 import lzma
+import sys
 import zlib
 from datetime import datetime, timezone
 from decimal import Context
@@ -756,13 +757,16 @@ else:
 def zstandard_read_block(decoder):
     length = read_long(decoder)
     data = decoder.read_fixed(length)
-    return BytesIO(zstandard.ZstdDecompressor().decompressobj().decompress(data))
+    return BytesIO(zstd.decompress(data))
 
 
 try:
-    import zstandard
+    if sys.version_info >= (3, 14):
+        from compression import zstd
+    else:
+        from backports import zstd
 except ImportError:
-    BLOCK_READERS["zstandard"] = missing_codec_lib("zstandard", "zstandard")
+    BLOCK_READERS["zstandard"] = missing_codec_lib("zstandard", "backports.zstd")
 else:
     BLOCK_READERS["zstandard"] = zstandard_read_block
 

--- a/fastavro/_write.pyx
+++ b/fastavro/_write.pyx
@@ -575,18 +575,21 @@ if BLOCK_WRITERS.get("snappy") is None:
 
 
 try:
-    import zstandard as zstd
+    if sys.version_info >= (3, 14):
+        from compression import zstd
+    else:
+        from backports import zstd
 except ImportError:
-    BLOCK_WRITERS["zstandard"] = _missing_dependency("zstandard", "zstandard")
+    BLOCK_WRITERS["zstandard"] = _missing_dependency("zstandard", "backports.zstd")
 
 
 cpdef zstandard_write_block(object fo, bytes block_bytes, compression_level):
     """Write block in "zstandard" codec."""
     cdef bytearray tmp = bytearray()
     if compression_level is not None:
-        data = zstd.ZstdCompressor(level=compression_level).compress(block_bytes)
+        data = zstd.compress(block_bytes, level=compression_level)
     else:
-        data = zstd.ZstdCompressor().compress(block_bytes)
+        data = zstd.compress(block_bytes)
     write_long(tmp, len(data))
     fo.write(tmp)
     fo.write(data)

--- a/freethreading_developer_requirements.txt
+++ b/freethreading_developer_requirements.txt
@@ -12,6 +12,7 @@ black; implementation_name != "pypy"
 
 # codec libraries (snappy is intentionally left off this list as it requires other system libraries to be installed and is non-trivial)
 cramjam
+backports.zstd ; python_version<'3.14'
 # Also don't install on windows for similar reasons
 lz4; sys_platform != 'win32'
 zlib_ng

--- a/setup.py
+++ b/setup.py
@@ -74,9 +74,9 @@ setup(
     ],
     python_requires=">=3.9",
     extras_require={
-        "codecs": ["cramjam", "zstandard", "lz4"],
+        "codecs": ["cramjam", "backports.zstd ; python_version<'3.14'", "lz4"],
         "snappy": ["cramjam"],
-        "zstandard": ["zstandard"],
+        "zstandard": ["backports.zstd ; python_version<'3.14'"],
         "lz4": ["lz4"],
     },
     package_data={"fastavro": ["py.typed"]},


### PR DESCRIPTION
Python 3.14 introduces support for Zstandard in the standard library via the [`compression.zstd`](https://docs.python.org/3.14/library/compression.zstd.html) module ([PEP-784](https://peps.python.org/pep-0784/)).

This PR removes the `zstdandard` extra dependency in favor of the native support in Python 3.14+. For older Python versions, the [backport](https://github.com/Rogdham/backports.zstd) is used.

It also has the advantage of supporting free threading and win32 platforms.

_Full disclosure: I'm the author and maintainer of `backports.zstd`, and the maintainer of `pyzstd` (which code was used as a base for the integration into Python). I also helped with PEP-784 and its integration into CPython._